### PR TITLE
add wasm constructor for Rgb struct

### DIFF
--- a/crate/src/lib.rs
+++ b/crate/src/lib.rs
@@ -140,6 +140,7 @@ pub struct Rgb {
 
 #[wasm_bindgen]
 impl Rgb {
+    #[wasm_bindgen(constructor)]
     /// Create a new RGB struct.
     pub fn new(r: u8, g: u8, b: u8) -> Rgb {
         return Rgb {r: r, g: g, b: b}


### PR DESCRIPTION
Hi Silvia,

just wondering if it was okay to just add `#[wasm_bindgen(constructor)]` to Rgb struct. Then we are able to create an Rgb object in JS like `new module.Rgb(r, g, b)`. For now it's likely we can't pass parameters to constructor. If we call functions such as `set_red` afterwards, a null pointer error raises (`Javascript Error:  Error: null pointer passed to rust`). Tested on Chrome 79.0.3945.88, with latest codes from master branch. 