### PR TITLE
add experimental fast gaussian blur

### DIFF
--- a/crate/Cargo.toml
+++ b/crate/Cargo.toml
@@ -43,6 +43,11 @@ wee_alloc = { version = "0.4.2", optional = true }
 
 [dev-dependencies]
 time="0.2.1"
+criterion = "0.3"
+
+[[bench]]
+name = "photon_benchmark"
+harness = false
 
 [dependencies.web-sys]
 version = "0.3"

--- a/crate/benches/photon_benchmark.rs
+++ b/crate/benches/photon_benchmark.rs
@@ -1,0 +1,42 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion, BenchmarkId};
+use photon_rs::PhotonImage;
+use photon_rs::native::{open_image};
+use photon_rs::conv::{fast_gaussian_blur, gaussian_blur};
+
+fn gaussian_blur_3x3_1(img: &mut PhotonImage) {
+    fast_gaussian_blur(img, 1);
+}
+
+fn gaussian_blur_3x3_2(img: &mut PhotonImage) {
+    gaussian_blur(img);
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Gaussian Blur");
+
+    let mut img = open_image("examples/input_images/daisies_fuji.jpg");
+    group.bench_function(BenchmarkId::new("fast_gaussian_blur", 0),
+        |b| b.iter(|| gaussian_blur_3x3_1(&mut img)));
+
+    let mut img = open_image("examples/input_images/underground.jpg");
+    group.bench_function(BenchmarkId::new("fast_gaussian_blur", 1),
+        |b| b.iter(|| gaussian_blur_3x3_1(&mut img)));
+
+    img = open_image("examples/input_images/daisies_fuji.jpg");
+    group.bench_function(BenchmarkId::new("normal_gaussian_blur", 2), 
+        |b| b.iter(|| gaussian_blur_3x3_2(&mut img)));
+
+    img = open_image("examples/input_images/underground.jpg");
+    group.bench_function(BenchmarkId::new("normal_gaussian_blur", 3), 
+        |b| b.iter(|| gaussian_blur_3x3_2(&mut img)));
+
+
+    group.finish();
+}
+
+fn alter_sample_size() -> Criterion {
+    Criterion::default().sample_size(50)
+}
+
+criterion_group! { name = benches; config = alter_sample_size(); targets = criterion_benchmark }
+criterion_main!(benches);


### PR DESCRIPTION
Hi Silvia,

I tried to implement a linear-time approximate Gaussian blur algorithm following the introduction to this [link](http://blog.ivank.net/fastest-gaussian-blur.html ). Probably it could be a good complement of current blur functions.

I also wrote a very simple benchmark test based on crate `criterion` (I added it under `dev-dependencies`). The file is in `benches` and you could just run `cargo bench` to see results.

The benchmark only tested two images (`daisies_fuji.jpg` and `underground.jpg`) in `examples` and it showed some performance improvement as follows (hope I didn't make common benchmark mistakes = =):

```
     Running target/release/deps/photon_benchmark-6b32e3e6318ed175
Gnuplot not found, using plotters backend
Benchmarking Gaussian Blur/fast_gaussian_blur/0: Warming up for 3.0000 s
Warning: Unable to complete 50 samples in 5.0s. You may wish to increase target time to 25.8s or reduce sample count to 10.
Benchmarking Gaussian Blur/fast_gaussian_blur/0: Collecting 50 samples in estimated 25.773 s (1275 itera                                                                                                        Gaussian Blur/fast_gaussian_blur/0                
                        time:   [19.721 ms 20.272 ms 20.834 ms]
                        change: [+10.427% +13.307% +15.953%] (p = 0.00 < 0.05)
                        Performance has regressed.
Benchmarking Gaussian Blur/fast_gaussian_blur/1: Warming up for 3.0000 s
Warning: Unable to complete 50 samples in 5.0s. You may wish to increase target time to 64.4s or reduce sample count to 10.
Benchmarking Gaussian Blur/fast_gaussian_blur/1: Collecting 50 samples in estimated 64.365 s (1275 itera                                                                                                        Gaussian Blur/fast_gaussian_blur/1                
                        time:   [49.807 ms 50.403 ms 50.978 ms]
Found 2 outliers among 50 measurements (4.00%)
  2 (4.00%) high mild
Benchmarking Gaussian Blur/normal_gaussian_blur/2: Warming up for 3.0000 s
Warning: Unable to complete 50 samples in 5.0s. You may wish to increase target time to 56.3s or reduce sample count to 10.
Benchmarking Gaussian Blur/normal_gaussian_blur/2: Collecting 50 samples in estimated 56.258 s (1275 ite                                                                                                        Gaussian Blur/normal_gaussian_blur/2              
                        time:   [41.887 ms 42.543 ms 43.260 ms]
Found 2 outliers among 50 measurements (4.00%)
  1 (2.00%) low mild
  1 (2.00%) high mild
Benchmarking Gaussian Blur/normal_gaussian_blur/3: Warming up for 3.0000 s
Warning: Unable to complete 50 samples in 5.0s. You may wish to increase target time to 135.6s or reduce sample count to 10.
Benchmarking Gaussian Blur/normal_gaussian_blur/3: Collecting 50 samples in estimated 135.59 s (1275 ite                                                                                                        Gaussian Blur/normal_gaussian_blur/3              
                        time:   [103.38 ms 105.28 ms 106.84 ms]
Found 5 outliers among 50 measurements (10.00%)
  5 (10.00%) low mild

```

Average processing time reduces from 42.543 ms to 20.272  ms, and 105.28 ms to 50.403 ms for `daisies_fuji.jpg` and `underground.jpg`, respectively (but variance a little bit high).

Here are some examples:

**underground.jpg with `radius=10`:**

![raw_image_03](https://user-images.githubusercontent.com/11512033/76524355-e2296800-64a4-11ea-9abf-e1ddabde0c6c.png)

And the difference with standard Gaussian blur in Affinity Photo:

<img width="1001" alt="Screen Shot 2020-03-12 at 9 04 08 PM" src="https://user-images.githubusercontent.com/11512033/76524462-143aca00-64a5-11ea-8b79-2d8c74b99106.png">

**daisies_fuji.jpg with `radius=5`:**

![raw_image_04](https://user-images.githubusercontent.com/11512033/76524938-ea35d780-64a5-11ea-8347-9af2989ec050.png)

The difference with standard Gaussian blur in Affinity Photo:

<img width="961" alt="Screen Shot 2020-03-12 at 9 32 44 PM" src="https://user-images.githubusercontent.com/11512033/76526807-169f2300-64a9-11ea-8744-8c7f7e57da23.png">

I am looking forward to any advice.
