### PR TITLE
remove static lifetime

### DIFF
--- a/crate/src/native.rs
+++ b/crate/src/native.rs
@@ -22,7 +22,7 @@ use crate::{PhotonImage};
 /// 
 /// // ... image editing functionality here ...
 /// ```
-pub fn open_image(img_path: &'static str) -> PhotonImage {
+pub fn open_image(img_path: &str) -> PhotonImage {
     let img = image::open(img_path).unwrap();
 
     let (width, height) = img.dimensions();


### PR DESCRIPTION
removes static lifetime, as it does not allow to use non static variables for path in open_image