### PR TITLE
derive Clone trait for PhotonImage

### DIFF
--- a/crate/src/lib.rs
+++ b/crate/src/lib.rs
@@ -54,7 +54,7 @@ use serde::{Serialize, Deserialize};
 /// Provides the image's height, width, and contains the image's raw pixels.
 /// For use when communicating between JS and WASM, and also natively. 
 #[wasm_bindgen]
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct PhotonImage {
     raw_pixels: Vec<u8>,
     width: u32, 


### PR DESCRIPTION
Hello Silvia

Here is small patch to add Clone trait to PhotonImage, useful to duplicate images `image_copy = original.clone()`