### PR TITLE
Fixed #18 - blend() shifts colors

### DIFF
--- a/crate/src/multiple.rs
+++ b/crate/src/multiple.rs
@@ -94,7 +94,7 @@ pub fn blend(mut photon_image: &mut PhotonImage, photon_image2: &PhotonImage, bl
                 };
             
             img.put_pixel(x, y, image::Rgba {
-                    data: Srgba::from_linear(blended.into()).into_format().into_raw()
+                    data: blended.into_format().into_raw()
             });
 
         }


### PR DESCRIPTION
Hi Silvia,

Here is fix for issue #18, the problem was - color first loaded as linear srgba, and then after blending saved as nonlinear srgba