### PR TITLE
Round benchmark time taken display to 2 decimal places

### DIFF
--- a/site/src/scripts/demo.js
+++ b/site/src/scripts/demo.js
@@ -398,7 +398,7 @@ var newimg, watermark_img, img2;
     console.log("update benchmarks");
     let time_taken = endTime - startTime;
     let time_elem = document.getElementById("time");
-    time_elem.innerHTML = `Time: ${time_taken}ms`;
+    time_elem.innerHTML = `Time: ${time_taken.toFixed(2)}ms`;
   }
 
    function setUpImages() {


### PR DESCRIPTION
I noticed the benchmark time display wasn't rounded, causing the final digits and `ms` text to be cut off sometimes.

![A screenshot of the demo page showing a benchmark time value of 20.88999981060624 milliseconds exactly](https://user-images.githubusercontent.com/5085260/84187166-f07e2480-aa91-11ea-86dd-a8a4c38a4d49.png)

This PR makes the time display round to 2 decimal places using [`Number.toFixed()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toFixed).

![A screenshot of the demo page showing a rounded benchmark time value of 27.86 milliseconds](https://user-images.githubusercontent.com/5085260/84187245-10154d00-aa92-11ea-9c05-c66d9b689e1c.png)


The choice of 2 digits is a bit arbitrary but it seems like good enough precision to still get the point across 🚀 