### PR TITLE
fixes method name: 'resize_img_browser' is preferable

### DIFF
--- a/crate/src/transform.rs
+++ b/crate/src/transform.rs
@@ -184,7 +184,7 @@ fn filter_type_from_sampling_filter(
 /// * `sampling_filter` - Nearest = 1, Triangle = 2, CatmullRom = 3, Gaussian = 4, Lanczos3 = 5
 #[cfg(target_arch = "wasm32")]
 #[wasm_bindgen]
-pub fn resizeimg_browser(
+pub fn resize_img_browser(
     photon_img: &PhotonImage,
     width: u32,
     height: u32,


### PR DESCRIPTION
name 'resize_img_browser' is preferable rather than 'resizeimg_browser', don't you think?

And you've already use 'resize_img_browser' at `webpack_demo/js/index.js:74`.