### PR TITLE
Feature request: panic-free functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,43 +9,43 @@
 
 <div align="center">
 
-  [![Status](https://img.shields.io/badge/status-active-success.svg)]() 
+  [![Status](https://img.shields.io/badge/status-active-success.svg)]()
   [![GitHub Issues](https://img.shields.io/github/issues/silvia-odwyer/photon.svg)](https://github.com/silvia-odwyer/photon/issues)
   [![GitHub Pull Requests](https://img.shields.io/github/issues-pr/silvia-odwyer/photon.svg)](https://github.com/silvia-odwyer/photon/pulls)
   [![Gitter chat](https://badges.gitter.im/silvia-odwyer/photon.png)](https://gitter.im/photonlibrary/community "Gitter chat")
-  [![NPM Monthly Downloads](https://img.shields.io/npm/dm/@silvia-odwyer/photon.png)]() 
+  [![NPM Monthly Downloads](https://img.shields.io/npm/dm/@silvia-odwyer/photon.png)]()
 
 </div>
 
 ---
 
 <p align="center"> High-performance, cross-platform Rust/WebAssembly image processing library
-    <br> 
+    <br>
 </p>
 
 ## 📝 Table of Contents
 - [Get Started with WebAssembly](https://github.com/silvia-odwyer/photon#get-started-with-webassembly)
-- [Get Started Natively](https://github.com/silvia-odwyer/photon#getting-started)
+- [Get Started Natively](https://github.com/silvia-odwyer/photon#get-started-natively)
 - [Documentation](https://docs.rs/photon-rs/)
 - [Official Website](https://silvia-odwyer.github.io/photon/)
 - [All Available Functions](https://silvia-odwyer.github.io/photon/docs/photon/all.html)
 - [Got Questions? Ask Here!](https://github.com/silvia-odwyer/photon#got-questions)
 
-Photon is a high-performance Rust image processing library, which compiles to WebAssembly, allowing for 
-safe, blazing-fast image processing both natively and on the web. 
+Photon is a high-performance Rust image processing library, which compiles to WebAssembly, allowing for
+safe, blazing-fast image processing both natively and on the web.
 
 You can run Photon:
-- natively 
+- natively
 - in the browser with WebAssembly
 - on Node with WebAssembly
 
-### Features 
+### Features
 - **Fast:** Photon outperforms even the fastest of libraries, including ImageMagick. On the web, its high-performance allows it to run at near-native speed. Benchmarks can be found [here](https://github.com/silvia-odwyer/photon/wiki/Benchmarks).
 - **Call with JS:** Want to use Photon on the web or with Node? Using a simple npm package, you're good to go. Get all the benefits of WebAssembly
-with zero-cost abstraction. 
+with zero-cost abstraction.
 - **Use Natively:** For command-line apps, native photo editing apps, and so forth, Photon's core codebase is in Rust, allowing for cross-platform
 development.
-- **Pure Rust** - Unlike other libraries, 100% of the library's codebase is written in Rust, so security and safety is guaranteed. 
+- **Pure Rust** - Unlike other libraries, 100% of the library's codebase is written in Rust, so security and safety is guaranteed.
 
 ### Live Demo
 View the [official demo of WASM in action](https://silvia-odwyer.github.io/photon/demo.html).
@@ -65,15 +65,15 @@ View the [official documentation](https://docs.rs/photon-rs/).
 96 customisable functions are available, for varying image effects.
 
 Functions include:
-- **Image correction**: Hue rotation, sharpening, brightness adjustment, adjusting saturation, lightening/darkening all within various colour spaces. 
+- **Image correction**: Hue rotation, sharpening, brightness adjustment, adjusting saturation, lightening/darkening all within various colour spaces.
 - **Resizing**: Resize images both natively and on the web.
-- **Convolutions**: Sobel filters, blurs, Laplace effects, edge detection, etc., 
+- **Convolutions**: Sobel filters, blurs, Laplace effects, edge detection, etc.,
 - **Channel manipulation**: Increasing/decreasing RGB channel values, swapping channels, removing channels, etc.
 - **Monochrome effects**: Monochrome tints, greyscaling of various forms, thresholding, sepia, averaging RGB values
-- **Colour manipulation**: Work with the image in various colour spaces such as HSL, LCh, and sRGB, and adjust the colours accordingly. 
-- **Filters**: Over 30 pre-set filters available, incorporating various effects and transformations. 
-- **Watermarking**: Watermark images in multiple formats. 
-- **Blending**: Blend images together using 10 different techniques, change image backgrounds. 
+- **Colour manipulation**: Work with the image in various colour spaces such as HSL, LCh, and sRGB, and adjust the colours accordingly.
+- **Filters**: Over 30 pre-set filters available, incorporating various effects and transformations.
+- **Watermarking**: Watermark images in multiple formats.
+- **Blending**: Blend images together using 10 different techniques, change image backgrounds.
 
 ## Get Started Natively
 
@@ -84,9 +84,9 @@ Add the following line to the dependencies section of your Rust project's Cargo.
 ```toml
 [dependencies]
 photon-rs = "0.2.0"
-``` 
+```
 
-#### Using Photon Natively 
+#### Using Photon Natively
 The following code opens an image from the filesystem, applies an effect, and outputs it as a PNG.
 
 Here is a code sample to get you started:
@@ -95,16 +95,17 @@ Here is a code sample to get you started:
 extern crate photon_rs;
 use photon_rs::native::{open_image, save_image};
 
-fn main() {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Open the image (a PhotonImage is returned)
-    let mut img = open_image("test_image.PNG");
+    let mut img = open_image("test_image.PNG")?;
 
     // Increment the red channel by 40
     photon_rs::channels::alter_red_channel(&mut img, 40);
 
     // Write file to filesystem.
-    save_image(img, "raw_image.JPG");    
+    save_image(img, "raw_image.JPG")?;
 
+    Ok(())
 }
 ```
 
@@ -112,7 +113,7 @@ fn main() {
 [For more examples, check out the guide on how to get started with Photon natively.](https://silvia-odwyer.github.io/photon/guide/using-photon-natively/)
 
 ## Get Started With WebAssembly
-### Using a Bundler? 
+### Using a Bundler?
 #### Installing Photon
 If you're using Webpack or a bundler to build your project, install Photon via npm:
 
@@ -135,14 +136,14 @@ npm install @silvia-odwyer/photon-node
 <!-- ##### NodeJS Tutorial
 See the [NodeJS tutorial, which shows how to use Photon with NodeJS](). -->
 
-## Modules 
+## Modules
 Photon contains a series of modules, which include:
 
 - `effects`: Various image effects, including adding offsets, thresholding, duotoning, solarization, etc.,
 - `channels`: Functions related to increasing/decreasing the red, green, and blue channels of the image data.
-- `filters`: Preset filters, which alter the rgb channels of the image. Contains over 20. 
-- `conv`: Laplace, Sobel, emboss; image proc functions which require image convolution. 
--  `noise`: Noise generation of varying tints and hues. 
+- `filters`: Preset filters, which alter the rgb channels of the image. Contains over 20.
+- `conv`: Laplace, Sobel, emboss; image proc functions which require image convolution.
+-  `noise`: Noise generation of varying tints and hues.
 - `multiple`: A module for dealing with multiple images, such as watermarking images, etc.,
 - `correction`: Hue rotation, adjusting saturation, lightening/darkening: all techniques available in multiple colour spaces, which lead to varying effects.
 
@@ -155,40 +156,40 @@ git clone https://github.com/silvia-odwyer/photon
 Run the binary, which will perform an image processing function on an image:
 ```sh
 cd crate
-cargo run --release 
+cargo run --release
 ```
 
 Compare the original image with the outputted image, and you'll see the desired effect has been applied.
 
-## Got Questions? 
+## Got Questions?
 If you have further questions about this library, you can ask them on [Gitter](https://gitter.im/photonlibrary/community) or [Spectrum](https://spectrum.chat/photonlibrary), and I'll get back to you!
 
-If there are any issues involving running/using the library, make sure to open an issue, it would be greatly appreciated, 
-and will help improve the library. 
+If there are any issues involving running/using the library, make sure to open an issue, it would be greatly appreciated,
+and will help improve the library.
 
 - [Spectrum](https://spectrum.chat/photonlibrary)
 - [Gitter](https://gitter.im/photonlibrary/community)
 
 ## Additional Notes
-Functions have been designed with flexibility in mind, so that full customization of effects and filters can be utilised; for every function, hundreds of differing image effects/tints/hues can be created, just by changing parameters slightly, so with every function comes the ability to fully experiment. 
+Functions have been designed with flexibility in mind, so that full customization of effects and filters can be utilised; for every function, hundreds of differing image effects/tints/hues can be created, just by changing parameters slightly, so with every function comes the ability to fully experiment.
 
 For developers who would like to work with high-level constructs can do so, such as applying effects to imagery (eg: Laplace or Sobel)
-or filters; this library provides a complete suite of functions to do so, as well as in-built filters and presets. 
+or filters; this library provides a complete suite of functions to do so, as well as in-built filters and presets.
 
 `photon` can be thought of as a high-level wrapper to the Rust `image` crate, but conversely also includes functions which provide low-level access to pixel and channel manipulation, perfect for developers who wish to work with this data directly.
 
 ## Contributing
 
-Photon is always ready for new filters and functions, so if you'd like to contribute, we're always ready to accept new Pull Requests or investigate new issues. 
+Photon is always ready for new filters and functions, so if you'd like to contribute, we're always ready to accept new Pull Requests or investigate new issues.
 
-## To Do 
-- Selective colorization 
+## To Do
+- Selective colorization
 - Fade
 - Pixelisation
 - Blend images using browser-specific functions for WASM version of library.
 - Vintage images with light leaks, grains, etc.,
 - Normalisation
-- Gamma correction 
+- Gamma correction
 - Duotone filtering
 - Tests in a headless web browser for WebAssembly version of library
 
@@ -196,7 +197,7 @@ Photon is always ready for new filters and functions, so if you'd like to contri
 
 * **Silvia O'Dwyer** - [@silvia-odwyer](https://github.com/silvia-odwyer)
 * **Ivan Zvonimir Horvat** - [@Horki](https://github.com/Horki)
-* **Future You(?)** - (See Contributing above ;) 
+* **Future You(?)** - (See Contributing above ;)
 
 ## License
 This project is licensed under the Apache 2.0 License - see the [LICENSE.md](LICENSE.md) file for details.

--- a/crate/Cargo.toml
+++ b/crate/Cargo.toml
@@ -28,6 +28,7 @@ base64="0.11.0"
 time="0.2.1"
 wasm-bindgen = "0.2.25"
 serde = { version = "1.0", features = ["derive"] }
+thiserror = "1.0"
 
 # The `console_error_panic_hook` crate provides better debugging of panics by
 # logging them with `console.error`. This is great for development, but requires
@@ -56,9 +57,9 @@ features = [
   "HtmlElement",
   "Node",
   "Window",
-  "CanvasRenderingContext2d", 
-  "ImageData", 
-  "HtmlCanvasElement", 
+  "CanvasRenderingContext2d",
+  "ImageData",
+  "HtmlCanvasElement",
   "HtmlImageElement",
   "console",
   'CssStyleDeclaration',

--- a/crate/benches/photon_benchmark.rs
+++ b/crate/benches/photon_benchmark.rs
@@ -20,7 +20,7 @@ fn criterion_benchmark(c: &mut Criterion) {
 
 fn invert_image() {
     // Open the image (a PhotonImage is returned)
-    let mut img = open_image("examples/input_images/underground.jpg");
+    let mut img = open_image("examples/input_images/underground.jpg").expect("File should open");
 
     // Invert the image
     photon_rs::channels::invert(&mut img);
@@ -28,28 +28,28 @@ fn invert_image() {
     let output_img_path = "output.jpg";
 
     // Write to filesystem
-    save_image(img, output_img_path);
+    save_image(img, output_img_path).expect("File should be saved");
 }
 
 fn resize_png() {
-    let mut img = open_image("examples/input_images/underground.png");
+    let mut img = open_image("examples/input_images/underground.png").expect("File should open");
 
     let resized_img = resize(&mut img, 800, 600, SamplingFilter::Lanczos3);
 
     let output_img_path = "output.png";
 
-    save_image(resized_img, output_img_path);
+    save_image(resized_img, output_img_path).expect("File should be saved");
 }
 
 fn resize_jpg() {
     // Open the image (a PhotonImage is returned)
-    let mut img = open_image("examples/input_images/underground.jpg");
+    let mut img = open_image("examples/input_images/underground.jpg").expect("File should open");
 
     let resized_img = resize(&mut img, 800, 600, SamplingFilter::Lanczos3);
 
     let output_img_path = "output.jpg";
 
-    save_image(resized_img, output_img_path);
+    save_image(resized_img, output_img_path).expect("File should be saved");
 }
 
 fn alter_sample_size() -> Criterion {

--- a/crate/examples/add_text.rs
+++ b/crate/examples/add_text.rs
@@ -3,14 +3,14 @@ extern crate photon_rs as photon;
 extern crate time;
 use time::Instant;
 
-fn main() {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Replace the variable file_name with whatever image you would like to apply filters to
     // Ensure it is in the example_output directory, which can be found one sub-dir inside the photon dir.
     // However the image referenced below, along with sample images, have been included in the dir.
     let file_name = "examples/input_images/daisies_fuji.jpg";
 
     // Open the image
-    let mut img = photon::native::open_image(file_name);
+    let mut img = photon::native::open_image(file_name)?;
 
     let start = Instant::now();
 
@@ -18,7 +18,7 @@ fn main() {
     photon::text::draw_text_with_border(&mut img, "Welcome to Photon!", 10, 20);
 
     // Write the contents of this image in PNG format.
-    photon::native::save_image(img, "output_new_image.png");
+    photon::native::save_image(img, "output_new_image.png")?;
     let end = Instant::now();
     println!(
         "Took {} seconds to add text to image.",
@@ -26,4 +26,6 @@ fn main() {
     );
 
     println!("Check example_output dir for image with text applied.\nYou can compare them with the original in {}", file_name);
+
+    Ok(())
 }

--- a/crate/examples/example.rs
+++ b/crate/examples/example.rs
@@ -3,7 +3,7 @@ extern crate photon_rs as photon;
 extern crate time;
 use time::Instant;
 
-fn main() {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Replace the variable file_name with whatever image you would like to apply filters to
     // Ensure it is in the example_output directory, which can be found one sub-dir inside the photon dir.
     // However the image referenced below, along with sample images, have been included in the dir.
@@ -14,7 +14,7 @@ fn main() {
         ["saturate", "desaturate", "lighten", "darken", "shift_hue"];
 
     for &effect in effects.iter() {
-        let mut img = photon::native::open_image(file_name);
+        let mut img = photon::native::open_image(file_name)?;
         let start = Instant::now();
 
         // Apply the effect in the HSV colour space
@@ -24,7 +24,7 @@ fn main() {
         photon::native::save_image(
             img,
             &format!("output_{}.jpg", effect)[..],
-        );
+        )?;
 
         let end = Instant::now();
         println!(
@@ -34,4 +34,6 @@ fn main() {
         );
     }
     println!("Check example_output dir for filtered images.\nYou can compare them with the original in {}", file_name);
+
+    Ok(())
 }

--- a/crate/examples/seam_carver.rs
+++ b/crate/examples/seam_carver.rs
@@ -2,12 +2,12 @@ extern crate image;
 extern crate photon_rs;
 extern crate time;
 
-fn main() {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     let file_name = "examples/input_images/daisies_fuji.jpg";
     println!("file name = {}", file_name);
 
     // // Open the image
-    let mut img = photon_rs::native::open_image(file_name);
+    let mut img = photon_rs::native::open_image(file_name)?;
     let start = time::Instant::now();
     // Seam Carver
     let (w, h) = (img.get_width(), img.get_height());
@@ -18,10 +18,12 @@ fn main() {
     println!("after = w: {}, h: {}", w, h);
 
     // Write the contents of this image in JPEG format.
-    photon_rs::native::save_image(res, "output_seam_carver.jpg");
+    photon_rs::native::save_image(res, "output_seam_carver.jpg")?;
     let end = time::Instant::now();
     println!(
         "Took {} seconds to seam carve image.",
         (end - start).as_seconds_f64()
     );
+
+    Ok(())
 }

--- a/crate/src/bin/bin.rs
+++ b/crate/src/bin/bin.rs
@@ -5,9 +5,9 @@ use photon_rs::channels::alter_red_channel;
 use photon_rs::native::{open_image, save_image};
 use time::Instant;
 
-fn main() {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Open the image (a PhotonImage is returned)
-    let mut img = open_image("examples/input_images/daisies_fuji.jpg");
+    let mut img = open_image("examples/input_images/daisies_fuji.jpg")?;
 
     let start = Instant::now();
     // Increment the red channel by 40
@@ -16,7 +16,7 @@ fn main() {
     let output_img_path = "output.jpg";
 
     // Write file to filesystem.
-    save_image(img, output_img_path);
+    save_image(img, output_img_path)?;
     let end = Instant::now();
     println!(
         "Took {} seconds to increment red channel by 40 on image.",
@@ -27,4 +27,6 @@ fn main() {
         "Saved image: {}. Please check this directory for the image.",
         output_img_path
     );
+
+    Ok(())
 }

--- a/crate/src/channels.rs
+++ b/crate/src/channels.rs
@@ -24,26 +24,26 @@ use crate::iter::ImageIterator;
 ///
 /// ## Example
 ///
-/// ```
+/// ```no_run
 /// // For example, to increase the Red channel for all pixels by 10:
 /// use photon_rs::channels::alter_channel;
 /// use photon_rs::native::{open_image, save_image};
 ///
-/// let mut img = open_image("img.jpg");
+/// let mut img = open_image("img.jpg").expect("File should open");
 /// alter_channel(&mut img, 0_usize, 10_i16);
 /// // Write the contents of this image in JPG format.
-/// save_image(img, "new_image.jpg");
+/// save_image(img, "new_image.jpg").expect("File should be saved");
 /// ```
 ///
 /// Adds a constant to a select R, G, or B channel's value.
 ///
 /// ### Decrease a channel's value
 /// // For example, to decrease the Green channel for all pixels by 20:
-/// ```
+/// ```no_run
 /// use photon_rs::channels::alter_channel;
 /// use photon_rs::native::open_image;
 ///
-/// let mut img = open_image("img.jpg");
+/// let mut img = open_image("img.jpg").expect("File should open");
 /// alter_channel(&mut img, 1_usize, -20_i16);
 /// ```
 /// **Note**: Note the use of a minus symbol when decreasing the channel.
@@ -71,13 +71,13 @@ pub fn alter_channel(img: &mut PhotonImage, channel: usize, amt: i16) {
 ///
 /// # Example
 ///
-/// ```
+/// ```no_run
 /// // For example, to increase the Red channel for all pixels by 10:
 /// use photon_rs::channels::alter_red_channel;
 /// use photon_rs::native::open_image;
 ///
-/// let mut img = open_image("img.jpg");
-/// alter_red_channel(&mut mg, 10_i16);
+/// let mut img = open_image("img.jpg").expect("File should open");
+/// alter_red_channel(&mut img, 10_i16);
 /// ```
 #[wasm_bindgen]
 pub fn alter_red_channel(photon_image: &mut PhotonImage, amt: i16) {
@@ -92,12 +92,12 @@ pub fn alter_red_channel(photon_image: &mut PhotonImage, amt: i16) {
 ///
 /// # Example
 ///
-/// ```
+/// ```no_run
 /// // For example, to increase the Green channel for all pixels by 20:
 /// use photon_rs::channels::alter_green_channel;
 /// use photon_rs::native::open_image;
 ///
-/// let mut img = open_image("img.jpg");
+/// let mut img = open_image("img.jpg").expect("File should open");
 /// alter_green_channel(&mut img, 20_i16);
 /// ```
 #[wasm_bindgen]
@@ -113,12 +113,12 @@ pub fn alter_green_channel(img: &mut PhotonImage, amt: i16) {
 ///
 /// # Example
 ///
-/// ```
+/// ```no_run
 /// // For example, to increase the Blue channel for all pixels by 10:
 /// use photon_rs::channels::alter_blue_channel;
 /// use photon_rs::native::open_image;
 ///
-/// let mut img = open_image("img.jpg");
+/// let mut img = open_image("img.jpg").expect("File should open");
 /// alter_blue_channel(&mut img, 10_i16);
 /// ```
 #[wasm_bindgen]
@@ -137,12 +137,12 @@ pub fn alter_blue_channel(img: &mut PhotonImage, amt: i16) {
 ///
 /// # Example
 ///
-/// ```
+/// ```no_run
 /// // For example, to increase the values of the Red and Blue channels per pixel:
 /// use photon_rs::channels::alter_two_channels;
 /// use photon_rs::native::open_image;
 ///
-/// let mut img = open_image("img.jpg");
+/// let mut img = open_image("img.jpg").expect("File should open");
 /// alter_two_channels(&mut img, 0_usize, 10_i16, 2_usize, 20_i16);
 /// ```
 #[wasm_bindgen]
@@ -186,13 +186,13 @@ pub fn alter_two_channels(
 ///
 /// # Example
 ///
-/// ```
+/// ```no_run
 /// // For example, to increase the values of the Red channel by 10, the Green channel by 20,
 /// // and the Blue channel by 50:
 /// use photon_rs::channels::alter_channels;
 /// use photon_rs::native::open_image;
 ///
-/// let mut img = open_image("img.jpg");
+/// let mut img = open_image("img.jpg").expect("File should open");
 /// alter_channels(&mut img, 10_i16, 20_i16, 50_i16);
 /// ```
 #[wasm_bindgen]
@@ -230,12 +230,12 @@ pub fn alter_channels(img: &mut PhotonImage, r_amt: i16, g_amt: i16, b_amt: i16)
 ///
 /// # Example
 ///
-/// ```
+/// ```no_run
 /// // For example, to remove the Red channel with a min_filter of 100:
 /// use photon_rs::channels::remove_channel;
 /// use photon_rs::native::open_image;
 ///
-/// let mut img = open_image("img.jpg");
+/// let mut img = open_image("img.jpg").expect("File should open");
 /// remove_channel(&mut img, 0_usize, 100_u8);
 /// ```
 #[wasm_bindgen]
@@ -259,12 +259,12 @@ pub fn remove_channel(img: &mut PhotonImage, channel: usize, min_filter: u8) {
 ///
 /// # Example
 ///
-/// ```
+/// ```no_run
 /// // For example, to remove the red channel for red channel pixel values less than 50:
 /// use photon_rs::channels::remove_red_channel;
 /// use photon_rs::native::open_image;
 ///
-/// let mut img = open_image("img.jpg");
+/// let mut img = open_image("img.jpg").expect("File should open");
 /// remove_red_channel(&mut img, 50_u8);
 /// ```
 #[wasm_bindgen]
@@ -280,12 +280,12 @@ pub fn remove_red_channel(img: &mut PhotonImage, min_filter: u8) {
 ///
 /// # Example
 ///
-/// ```
+/// ```no_run
 /// // For example, to remove the green channel for green channel pixel values less than 50:
 /// use photon_rs::channels::remove_green_channel;
 /// use photon_rs::native::open_image;
 ///
-/// let mut img = open_image("img.jpg");
+/// let mut img = open_image("img.jpg").expect("File should open");
 /// remove_green_channel(&mut img, 50_u8);
 /// ```
 #[wasm_bindgen]
@@ -301,12 +301,12 @@ pub fn remove_green_channel(img: &mut PhotonImage, min_filter: u8) {
 ///
 /// # Example
 ///
-/// ```
+/// ```no_run
 /// // For example, to remove the blue channel for blue channel pixel values less than 50:
 /// use photon_rs::channels::remove_blue_channel;
 /// use photon_rs::native::open_image;
 ///
-/// let mut img = open_image("img.jpg");
+/// let mut img = open_image("img.jpg").expect("File should open");
 /// remove_blue_channel(&mut img, 50_u8);
 /// ```
 #[wasm_bindgen]
@@ -323,12 +323,12 @@ pub fn remove_blue_channel(img: &mut PhotonImage, min_filter: u8) {
 ///
 /// # Example
 ///
-/// ```
+/// ```no_run
 /// // For example, to swap the values of the Red channel with the values of the Blue channel:
 /// use photon_rs::channels::swap_channels;
 /// use photon_rs::native::open_image;
 ///
-/// let mut img = open_image("img.jpg");
+/// let mut img = open_image("img.jpg").expect("File should open");
 /// swap_channels(&mut img, 0_usize, 2_usize);
 /// ```
 #[wasm_bindgen]
@@ -364,14 +364,14 @@ pub fn swap_channels(img: &mut PhotonImage, mut channel1: usize, mut channel2: u
 ///
 /// # Example
 ///
-/// ```
+/// ```no_run
 /// // For example, to only rotate the pixels that are of RGB value RGB{20, 40, 60}:
 /// use photon_rs::Rgb;
 /// use photon_rs::channels::selective_hue_rotate;
 /// use photon_rs::native::open_image;
 ///
 /// let ref_color = Rgb::new(20_u8, 40_u8, 60_u8);
-/// let mut img = open_image("img.jpg");
+/// let mut img = open_image("img.jpg").expect("File should open");
 /// selective_hue_rotate(&mut img, ref_color, 180_f32);
 /// ```
 #[wasm_bindgen]
@@ -428,11 +428,11 @@ pub fn selective_hue_rotate(
 /// * `photon_image` - A DynamicImage that contains a view into the image.
 /// # Example
 ///
-/// ```
+/// ```no_run
 /// use photon_rs::channels::invert;
 /// use photon_rs::native::open_image;
 ///
-/// let mut img = open_image("img.jpg");
+/// let mut img = open_image("img.jpg").expect("File should open");
 /// invert(&mut img);
 /// ```
 #[wasm_bindgen]
@@ -475,14 +475,14 @@ pub fn color_sim(lab1: Lab, lab2: Lab) -> i64 {
 ///
 /// # Example
 ///
-/// ```
+/// ```no_run
 /// // For example, to only lighten the pixels that are of or similar to RGB value RGB{20, 40, 60}:
 /// use photon_rs::Rgb;
 /// use photon_rs::channels::selective_lighten;
 /// use photon_rs::native::open_image;
 ///
 /// let ref_color = Rgb::new(20_u8, 40_u8, 60_u8);
-/// let mut img = open_image("img.jpg");
+/// let mut img = open_image("img.jpg").expect("File should open");
 /// selective_lighten(&mut img, ref_color, 0.2_f32);
 /// ```
 #[wasm_bindgen]
@@ -502,14 +502,14 @@ pub fn selective_lighten(img: &mut PhotonImage, ref_color: Rgb, amt: f32) {
 ///
 /// # Example
 ///
-/// ```
+/// ```no_run
 /// // For example, to only desaturate the pixels that are similar to the RGB value RGB{20, 40, 60}:
 /// use photon_rs::Rgb;
 /// use photon_rs::channels::selective_desaturate;
 /// use photon_rs::native::open_image;
 ///
 /// let ref_color = Rgb::new(20_u8, 40_u8, 60_u8);
-/// let mut img = open_image("img.jpg");
+/// let mut img = open_image("img.jpg").expect("File should open");
 /// selective_desaturate(&mut img, ref_color, 0.1_f32);
 /// ```
 #[wasm_bindgen]
@@ -529,14 +529,14 @@ pub fn selective_desaturate(img: &mut PhotonImage, ref_color: Rgb, amt: f32) {
 ///
 /// # Example
 ///
-/// ```
+/// ```no_run
 /// // For example, to only increase the saturation of pixels that are similar to the RGB value RGB{20, 40, 60}:
 /// use photon_rs::Rgb;
 /// use photon_rs::channels::selective_saturate;
 /// use photon_rs::native::open_image;
 ///
 /// let ref_color = Rgb::new(20_u8, 40_u8, 60_u8);
-/// let mut img = open_image("img.jpg");
+/// let mut img = open_image("img.jpg").expect("File should open");
 /// selective_saturate(&mut img, ref_color, 0.1_f32);
 /// ```
 #[wasm_bindgen]
@@ -612,14 +612,14 @@ fn selective(
 ///
 /// # Example
 ///
-/// ```
+/// ```no_run
 /// // For example, to greyscale all pixels that are *not* visually similar to the RGB colour RGB{20, 40, 60}:
 /// use photon_rs::Rgb;
 /// use photon_rs::channels::selective_greyscale;
 /// use photon_rs::native::open_image;
 ///
 /// let ref_color = Rgb::new(20_u8, 40_u8, 60_u8);
-/// let mut img = open_image("img.jpg");
+/// let mut img = open_image("img.jpg").expect("File should open");
 /// selective_greyscale(img, ref_color);
 /// ```
 #[wasm_bindgen]

--- a/crate/src/colour_spaces.rs
+++ b/crate/src/colour_spaces.rs
@@ -65,13 +65,13 @@ use crate::iter::ImageIterator;
 /// * `mode` - The effect desired to be applied. Choose from: `saturate`, `desaturate`, `shift_hue`, `darken`, `lighten`
 /// * `amt` - A float value from 0 to 1 which represents the amount the effect should be increased by.
 /// # Example
-/// ```
+/// ```no_run
 /// // For example to increase the saturation by 10%:
 /// use photon_rs::colour_spaces::lch;
 /// use photon_rs::native::open_image;
 ///
 /// // Open the image. A PhotonImage is returned.
-/// let mut img = open_image("img.jpg");
+/// let mut img = open_image("img.jpg").expect("File should open");
 /// lch(&mut img, "saturate", 0.1_f32);
 /// ```
 #[wasm_bindgen]
@@ -122,13 +122,13 @@ pub fn lch(mut photon_image: &mut PhotonImage, mode: &str, amt: f32) {
 /// * `mode` - The effect desired to be applied. Choose from: `saturate`, `desaturate`, `shift_hue`, `darken`, `lighten`
 /// * `amt` - A float value from 0 to 1 which represents the amount the effect should be increased by.
 /// # Example
-/// ```
+/// ```no_run
 /// // For example to increase the saturation by 10%:
 /// use photon_rs::colour_spaces::hsl;
 /// use photon_rs::native::open_image;
 ///
 /// // Open the image. A PhotonImage is returned.
-/// let mut img = open_image("img.jpg");
+/// let mut img = open_image("img.jpg").expect("File should open");
 /// hsl(&mut img, "saturate", 0.1_f32);
 /// ```
 #[wasm_bindgen]
@@ -182,13 +182,13 @@ pub fn hsl(mut photon_image: &mut PhotonImage, mode: &str, amt: f32) {
 /// * `amt` - A float value from 0 to 1 which represents the amount the effect should be increased by.
 ///
 /// # Example
-/// ```
+/// ```no_run
 /// // For example to increase the saturation by 10%:
 /// use photon_rs::colour_spaces::hsv;
 /// use photon_rs::native::open_image;
 ///
 /// // Open the image. A PhotonImage is returned.
-/// let mut img = open_image("img.jpg");
+/// let mut img = open_image("img.jpg").expect("File should open");
 /// hsv(&mut img, "saturate", 0.1_f32);
 /// ```
 #[wasm_bindgen]
@@ -233,13 +233,13 @@ pub fn hsv(photon_image: &mut PhotonImage, mode: &str, amt: f32) {
 /// * `mode` - A float value from 0 to 1 which is the amount to shift the hue by, or hue rotate by.
 ///
 /// # Example
-/// ```
+/// ```no_run
 /// // For example to hue rotate/shift the hue by 120 degrees in the HSL colour space:
 /// use photon_rs::colour_spaces::hue_rotate_hsl;
 /// use photon_rs::native::open_image;
 ///
 /// // Open the image. A PhotonImage is returned.
-/// let mut img = open_image("img.jpg");
+/// let mut img = open_image("img.jpg").expect("File should open");
 /// hue_rotate_hsl(&mut img, 120_f32);
 /// ```
 #[wasm_bindgen]
@@ -253,13 +253,13 @@ pub fn hue_rotate_hsl(img: &mut PhotonImage, degrees: f32) {
 /// * `mode` - A float value from 0 to 1 which is the amount to shift the hue by, or hue rotate by.
 ///
 /// # Example
-/// ```
+/// ```no_run
 /// // For example to hue rotate/shift the hue by 120 degrees in the HSV colour space:
 /// use photon_rs::colour_spaces::hue_rotate_hsv;
 /// use photon_rs::native::open_image;
 ///
 /// // Open the image. A PhotonImage is returned.
-/// let mut img = open_image("img.jpg");
+/// let mut img = open_image("img.jpg").expect("File should open");
 /// hue_rotate_hsv(&mut img, 120_f32);
 /// ```
 #[wasm_bindgen]
@@ -273,13 +273,13 @@ pub fn hue_rotate_hsv(img: &mut PhotonImage, degrees: f32) {
 /// * `mode` - A float value from 0 to 1 which is the amount to shift the hue by, or hue rotate by.
 ///
 /// # Example
-/// ```
+/// ```no_run
 /// // For example to hue rotate/shift the hue by 120 degrees in the HSL colour space:
 /// use photon_rs::colour_spaces::hue_rotate_lch;
 /// use photon_rs::native::open_image;
 ///
 /// // Open the image. A PhotonImage is returned.
-/// let mut img = open_image("img.jpg");
+/// let mut img = open_image("img.jpg").expect("File should open");
 /// hue_rotate_lch(&mut img, 120_f32);
 /// ```
 #[wasm_bindgen]
@@ -296,13 +296,13 @@ pub fn hue_rotate_lch(img: &mut PhotonImage, degrees: f32) {
 /// Increasing saturation by 80% would be represented by a `level` of 0.8
 ///
 /// # Example
-/// ```
+/// ```no_run
 /// // For example to increase saturation by 10% in the HSL colour space:
 /// use photon_rs::colour_spaces::saturate_hsl;
 /// use photon_rs::native::open_image;
 ///
 /// // Open the image. A PhotonImage is returned.
-/// let mut img = open_image("img.jpg");
+/// let mut img = open_image("img.jpg").expect("File should open");
 /// saturate_hsl(&mut img, 0.1_f32);
 /// ```
 #[wasm_bindgen]
@@ -318,13 +318,13 @@ pub fn saturate_hsl(img: &mut PhotonImage, level: f32) {
 /// Increasing saturation by 80% would be represented by a `level` of 0.8
 ///
 /// # Example
-/// ```
+/// ```no_run
 /// // For example to increase saturation by 40% in the Lch colour space:
 /// use photon_rs::colour_spaces::saturate_lch;
 /// use photon_rs::native::open_image;
 ///
 /// // Open the image. A PhotonImage is returned.
-/// let mut img = open_image("img.jpg");
+/// let mut img = open_image("img.jpg").expect("File should open");
 /// saturate_lch(&mut img, 0.4_f32);
 /// ```
 #[wasm_bindgen]
@@ -340,13 +340,13 @@ pub fn saturate_lch(img: &mut PhotonImage, level: f32) {
 /// Increasing saturation by 80% would be represented by a `level` of 0.8
 ///
 /// # Example
-/// ```
+/// ```no_run
 /// // For example to increase saturation by 30% in the HSV colour space:
 /// use photon_rs::colour_spaces::saturate_hsv;
 /// use photon_rs::native::open_image;
 ///
 /// // Open the image. A PhotonImage is returned.
-/// let mut img = open_image("img.jpg");
+/// let mut img = open_image("img.jpg").expect("File should open");
 /// saturate_hsv(&mut img, 0.3_f32);
 /// ```
 #[wasm_bindgen]
@@ -363,13 +363,13 @@ pub fn saturate_hsv(img: &mut PhotonImage, level: f32) {
 /// Lightening by 80% would be represented by a `level` of 0.8
 ///
 /// # Example
-/// ```
+/// ```no_run
 /// // For example to lighten an image by 10% in the LCh colour space:
 /// use photon_rs::colour_spaces::lighten_lch;
 /// use photon_rs::native::open_image;
 ///
 /// // Open the image. A PhotonImage is returned.
-/// let mut img = open_image("img.jpg");
+/// let mut img = open_image("img.jpg").expect("File should open");
 /// lighten_lch(&mut img, 0.1_f32);
 /// ```
 #[wasm_bindgen]
@@ -385,13 +385,13 @@ pub fn lighten_lch(img: &mut PhotonImage, level: f32) {
 /// Lightening by 80% would be represented by a `level` of 0.8
 ///
 /// # Example
-/// ```
+/// ```no_run
 /// // For example to lighten an image by 10% in the HSL colour space:
 /// use photon_rs::colour_spaces::lighten_hsl;
 /// use photon_rs::native::open_image;
 ///
 /// // Open the image. A PhotonImage is returned.
-/// let mut img = open_image("img.jpg");
+/// let mut img = open_image("img.jpg").expect("File should open");
 /// lighten_hsl(&mut img, 0.1_f32);
 /// ```
 #[wasm_bindgen]
@@ -408,13 +408,13 @@ pub fn lighten_hsl(img: &mut PhotonImage, level: f32) {
 /// Lightening by 80% would be represented by a `level` of 0.8
 ///
 /// # Example
-/// ```
+/// ```no_run
 /// // For example to lighten an image by 10% in the HSV colour space:
 /// use photon_rs::colour_spaces::lighten_hsv;
 /// use photon_rs::native::open_image;
 ///
 /// // Open the image. A PhotonImage is returned.
-/// let mut img = open_image("img.jpg");
+/// let mut img = open_image("img.jpg").expect("File should open");
 /// lighten_hsv(&mut img, 0.1_f32);
 /// ```
 #[wasm_bindgen]
@@ -431,13 +431,13 @@ pub fn lighten_hsv(img: &mut PhotonImage, level: f32) {
 /// Darkening by 80% would be represented by a `level` of 0.8
 ///
 /// # Example
-/// ```
+/// ```no_run
 /// // For example to darken an image by 10% in the LCh colour space:
 /// use photon_rs::colour_spaces::darken_lch;
 /// use photon_rs::native::open_image;
 ///
 /// // Open the image. A PhotonImage is returned.
-/// let mut img = open_image("img.jpg");
+/// let mut img = open_image("img.jpg").expect("File should open");
 /// darken_lch(&mut img, 0.1_f32);
 /// ```
 #[wasm_bindgen]
@@ -454,13 +454,13 @@ pub fn darken_lch(img: &mut PhotonImage, level: f32) {
 /// Darkening by 80% would be represented by a `level` of 0.8
 ///
 /// # Example
-/// ```
+/// ```no_run
 /// // For example to darken an image by 10% in the HSL colour space:
 /// use photon_rs::colour_spaces::darken_hsl;
 /// use photon_rs::native::open_image;
 ///
 /// // Open the image. A PhotonImage is returned.
-/// let mut img = open_image("img.jpg");
+/// let mut img = open_image("img.jpg").expect("File should open");
 /// darken_hsl(&mut img, 0.1_f32);
 /// ```
 #[wasm_bindgen]
@@ -477,13 +477,13 @@ pub fn darken_hsl(img: &mut PhotonImage, level: f32) {
 /// Darkening by 80% would be represented by a `level` of 0.8
 ///
 /// # Example
-/// ```
+/// ```no_run
 /// // For example to darken an image by 10% in the HSV colour space:
 /// use photon_rs::colour_spaces::darken_hsv;
 /// use photon_rs::native::open_image;
 ///
 /// // Open the image. A PhotonImage is returned.
-/// let mut img = open_image("img.jpg");
+/// let mut img = open_image("img.jpg").expect("File should open");
 /// darken_hsv(&mut img, 0.1_f32);
 /// ```
 #[wasm_bindgen]
@@ -500,13 +500,13 @@ pub fn darken_hsv(img: &mut PhotonImage, level: f32) {
 /// Desaturating by 80% would be represented by a `level` of 0.8
 ///
 /// # Example
-/// ```
+/// ```no_run
 /// // For example to desaturate an image by 10% in the HSV colour space:
 /// use photon_rs::colour_spaces::desaturate_hsv;
 /// use photon_rs::native::open_image;
 ///
 /// // Open the image. A PhotonImage is returned.
-/// let mut img = open_image("img.jpg");
+/// let mut img = open_image("img.jpg").expect("File should open");
 /// desaturate_hsv(&mut img, 0.1_f32);
 /// ```
 #[wasm_bindgen]
@@ -523,13 +523,13 @@ pub fn desaturate_hsv(img: &mut PhotonImage, level: f32) {
 /// Desaturating by 80% would be represented by a `level` of 0.8
 ///
 /// # Example
-/// ```
+/// ```no_run
 /// // For example to desaturate an image by 10% in the LCh colour space:
 /// use photon_rs::colour_spaces::desaturate_hsl;
 /// use photon_rs::native::open_image;
 ///
 /// // Open the image. A PhotonImage is returned.
-/// let mut img = open_image("img.jpg");
+/// let mut img = open_image("img.jpg").expect("File should open");
 /// desaturate_hsl(&mut img, 0.1_f32);
 /// ```
 #[wasm_bindgen]
@@ -546,13 +546,13 @@ pub fn desaturate_hsl(img: &mut PhotonImage, level: f32) {
 /// Desaturating by 80% would be represented by a `level` of 0.8
 ///
 /// # Example
-/// ```
+/// ```no_run
 /// // For example to desaturate an image by 10% in the LCh colour space:
 /// use photon_rs::colour_spaces::desaturate_lch;
 /// use photon_rs::native::open_image;
 ///
 /// // Open the image. A PhotonImage is returned.
-/// let mut img = open_image("img.jpg");
+/// let mut img = open_image("img.jpg").expect("File should open");
 /// desaturate_lch(&mut img, 0.1_f32);
 /// ```
 #[wasm_bindgen]
@@ -573,14 +573,14 @@ pub fn desaturate_lch(img: &mut PhotonImage, level: f32) {
 /// * `opacity` - the opacity of color when mixed to image. Float value from 0 to 1.
 /// # Example
 ///
-/// ```
+/// ```no_run
 /// // For example, to mix an image with rgb (50, 255, 254) and opacity 0.4:
 /// use photon_rs::Rgb;
 /// use photon_rs::colour_spaces::mix_with_colour;
 /// use photon_rs::native::open_image;
 ///
 /// let mix_colour = Rgb::new(50_u8, 255_u8, 254_u8);
-/// let mut img = open_image("img.jpg");
+/// let mut img = open_image("img.jpg").expect("File should open");
 /// mix_with_colour(&mut img, mix_colour, 0.4_f32);
 /// ```
 #[wasm_bindgen]

--- a/crate/src/conv.rs
+++ b/crate/src/conv.rs
@@ -24,12 +24,12 @@ fn conv(photon_image: &mut PhotonImage, kernel: Kernel) {
 ///
 /// # Example
 ///
-/// ```
+/// ```no_run
 /// // For example, to noise reduct an image:
 /// use photon_rs::conv::noise_reduction;
 /// use photon_rs::native::open_image;
 ///
-/// let mut img = open_image("img.jpg");
+/// let mut img = open_image("img.jpg").expect("File should open");
 /// noise_reduction(&mut img);
 /// ```
 /// Adds a constant to a select R, G, or B channel's value.
@@ -45,12 +45,12 @@ pub fn noise_reduction(photon_image: &mut PhotonImage) {
 ///
 /// # Example
 ///
-/// ```
+/// ```no_run
 /// // For example, to sharpen an image:
 /// use photon_rs::conv::sharpen;
 /// use photon_rs::native::open_image;
 ///
-/// let mut img = open_image("img.jpg");
+/// let mut img = open_image("img.jpg").expect("File should open");
 /// sharpen(&mut img);
 /// ```
 /// Adds a constant to a select R, G, or B channel's value.
@@ -66,12 +66,12 @@ pub fn sharpen(photon_image: &mut PhotonImage) {
 ///
 /// # Example
 ///
-/// ```
+/// ```no_run
 /// // For example, to increase the Red channel for all pixels by 10:
 /// use photon_rs::conv::edge_detection;
 /// use photon_rs::native::open_image;
 ///
-/// let mut img = open_image("img.jpg");
+/// let mut img = open_image("img.jpg").expect("File should open");
 /// edge_detection(&mut img);
 /// ```
 #[wasm_bindgen]
@@ -86,12 +86,12 @@ pub fn edge_detection(photon_image: &mut PhotonImage) {
 ///
 /// # Example
 ///
-/// ```
+/// ```no_run
 /// // For example, to apply an identity kernel convolution:
 /// use photon_rs::conv::identity;
 /// use photon_rs::native::open_image;
 ///
-/// let mut img = open_image("img.jpg");
+/// let mut img = open_image("img.jpg").expect("File should open");
 /// identity(&mut img);
 /// ```
 #[wasm_bindgen]
@@ -106,12 +106,12 @@ pub fn identity(photon_image: &mut PhotonImage) {
 ///
 /// # Example
 ///
-/// ```
+/// ```no_run
 /// // For example, to apply a box blur effect:
 /// use photon_rs::conv::box_blur;
 /// use photon_rs::native::open_image;
 ///
-/// let mut img = open_image("img.jpg");
+/// let mut img = open_image("img.jpg").expect("File should open");
 /// box_blur(&mut img);
 /// ```
 #[wasm_bindgen]
@@ -128,11 +128,11 @@ pub fn box_blur(photon_image: &mut PhotonImage) {
 /// * `radius` - blur radius
 /// # Example
 ///
-/// ```
+/// ```no_run
 /// use photon_rs::conv::gaussian_blur;
 /// use photon_rs::native::open_image;
 ///
-/// let mut img = open_image("img.jpg");
+/// let mut img = open_image("img.jpg").expect("File should open");
 /// gaussian_blur(&mut img, 3_i32);
 /// ```
 #[wasm_bindgen]
@@ -349,12 +349,12 @@ fn box_blur_vertical(
 ///
 /// # Example
 ///
-/// ```
+/// ```no_run
 /// // For example, to display the horizontal lines in an image:
 /// use photon_rs::conv::detect_horizontal_lines;
 /// use photon_rs::native::open_image;
 ///
-/// let mut img = open_image("img.jpg");
+/// let mut img = open_image("img.jpg").expect("File should open");
 /// detect_horizontal_lines(&mut img);
 /// ```
 #[wasm_bindgen]
@@ -369,12 +369,12 @@ pub fn detect_horizontal_lines(photon_image: &mut PhotonImage) {
 ///
 /// # Example
 ///
-/// ```
+/// ```no_run
 /// // For example, to display the vertical lines in an image:
 /// use photon_rs::conv::detect_vertical_lines;
 /// use photon_rs::native::open_image;
 ///
-/// let mut img = open_image("img.jpg");
+/// let mut img = open_image("img.jpg").expect("File should open");
 /// detect_vertical_lines(&mut img);
 /// ```
 #[wasm_bindgen]
@@ -389,12 +389,12 @@ pub fn detect_vertical_lines(photon_image: &mut PhotonImage) {
 ///
 /// # Example
 ///
-/// ```
+/// ```no_run
 /// // For example, to display the lines at a forty five degree angle in an image:
 /// use photon_rs::conv::detect_45_deg_lines;
 /// use photon_rs::native::open_image;
 ///
-/// let mut img = open_image("img.jpg");
+/// let mut img = open_image("img.jpg").expect("File should open");
 /// detect_45_deg_lines(&mut img);
 /// ```
 #[wasm_bindgen]
@@ -409,12 +409,12 @@ pub fn detect_45_deg_lines(photon_image: &mut PhotonImage) {
 ///
 /// # Example
 ///
-/// ```
+/// ```no_run
 /// // For example, to display the lines at a 135 degree angle in an image:
 /// use photon_rs::conv::detect_135_deg_lines;
 /// use photon_rs::native::open_image;
 ///
-/// let mut img = open_image("img.jpg");
+/// let mut img = open_image("img.jpg").expect("File should open");
 /// detect_135_deg_lines(&mut img);
 /// ```
 #[wasm_bindgen]
@@ -429,12 +429,12 @@ pub fn detect_135_deg_lines(photon_image: &mut PhotonImage) {
 ///
 /// # Example
 ///
-/// ```
+/// ```no_run
 /// // For example, to apply a laplace effect:
 /// use photon_rs::conv::laplace;
 /// use photon_rs::native::open_image;
 ///
-/// let mut img = open_image("img.jpg");
+/// let mut img = open_image("img.jpg").expect("File should open");
 /// laplace(&mut img);
 /// ```
 #[wasm_bindgen]
@@ -449,12 +449,12 @@ pub fn laplace(photon_image: &mut PhotonImage) {
 ///
 /// # Example
 ///
-/// ```
+/// ```no_run
 /// // For example, to apply this effect:
 /// use photon_rs::conv::edge_one;
 /// use photon_rs::native::open_image;
 ///
-/// let mut img = open_image("img.jpg");
+/// let mut img = open_image("img.jpg").expect("File should open");
 /// edge_one(&mut img);
 /// ```
 #[wasm_bindgen]
@@ -469,12 +469,12 @@ pub fn edge_one(photon_image: &mut PhotonImage) {
 ///
 /// # Example
 ///
-/// ```
+/// ```no_run
 /// // For example, to apply an emboss effect:
 /// use photon_rs::conv::emboss;
 /// use photon_rs::native::open_image;
 ///
-/// let mut img = open_image("img.jpg");
+/// let mut img = open_image("img.jpg").expect("File should open");
 /// emboss(&mut img);
 /// ```
 #[wasm_bindgen]
@@ -489,12 +489,12 @@ pub fn emboss(photon_image: &mut PhotonImage) {
 ///
 /// # Example
 ///
-/// ```
+/// ```no_run
 /// // For example, to apply a horizontal Sobel filter:
 /// use photon_rs::conv::sobel_horizontal;
 /// use photon_rs::native::open_image;
 ///
-/// let mut img = open_image("img.jpg");
+/// let mut img = open_image("img.jpg").expect("File should open");
 /// sobel_horizontal(&mut img);
 /// ```
 #[wasm_bindgen]
@@ -509,12 +509,12 @@ pub fn sobel_horizontal(photon_image: &mut PhotonImage) {
 ///
 /// # Example
 ///
-/// ```
+/// ```no_run
 /// // For example, to apply a horizontal Prewitt convolution effect:
 /// use photon_rs::conv::prewitt_horizontal;
 /// use photon_rs::native::open_image;
 ///
-/// let mut img = open_image("img.jpg");
+/// let mut img = open_image("img.jpg").expect("File should open");
 /// prewitt_horizontal(&mut img);
 /// ```
 #[wasm_bindgen]
@@ -529,12 +529,12 @@ pub fn prewitt_horizontal(photon_image: &mut PhotonImage) {
 ///
 /// # Example
 ///
-/// ```
+/// ```no_run
 /// // For example, to apply a vertical Sobel filter:
 /// use photon_rs::conv::sobel_vertical;
 /// use photon_rs::native::open_image;
 ///
-/// let mut img = open_image("img.jpg");
+/// let mut img = open_image("img.jpg").expect("File should open");
 /// sobel_vertical(&mut img);
 /// ```
 #[wasm_bindgen]

--- a/crate/src/effects.rs
+++ b/crate/src/effects.rs
@@ -17,15 +17,15 @@ use crate::iter::ImageIterator;
 ///
 /// # Arguments
 /// * `img` - A PhotonImage that contains a view into the image.
-/// * `offset` - The offset is added to the pixels in the image.  
+/// * `offset` - The offset is added to the pixels in the image.
 /// # Example
 ///
-/// ```
+/// ```no_run
 /// // For example, to offset pixels by 30 pixels on the red channel:
 /// use photon_rs::effects::offset;
 /// use photon_rs::native::open_image;
 ///
-/// let mut img = open_image("img.jpg");
+/// let mut img = open_image("img.jpg").expect("File should open");
 /// offset(&mut img, 0_usize, 30_u32);
 /// ```
 #[wasm_bindgen]
@@ -59,12 +59,12 @@ pub fn offset(photon_image: &mut PhotonImage, channel_index: usize, offset: u32)
 /// * `offset` - The offset you want to move the red channel by.
 /// # Example
 ///
-/// ```
+/// ```no_run
 /// // For example, to add an offset to the red channel by 30 pixels.
 /// use photon_rs::effects::offset_red;
 /// use photon_rs::native::open_image;
 ///
-/// let mut img = open_image("img.jpg");
+/// let mut img = open_image("img.jpg").expect("File should open");
 /// offset_red(&mut img, 30_u32);
 /// ```
 #[wasm_bindgen]
@@ -79,12 +79,12 @@ pub fn offset_red(img: &mut PhotonImage, offset_amt: u32) {
 /// * `offset` - The offset you want to move the green channel by.
 /// # Example
 ///
-/// ```
+/// ```no_run
 /// // For example, to add an offset to the green channel by 30 pixels.
 /// use photon_rs::effects::offset_green;
 /// use photon_rs::native::open_image;
 ///
-/// let mut img = open_image("img.jpg");
+/// let mut img = open_image("img.jpg").expect("File should open");
 /// offset_green(&mut img, 30_u32);
 /// ```
 #[wasm_bindgen]
@@ -100,11 +100,11 @@ pub fn offset_green(img: &mut PhotonImage, offset_amt: u32) {
 /// # Example
 /// // For example, to add an offset to the green channel by 40 pixels.
 ///
-/// ```
+/// ```no_run
 /// use photon_rs::effects::offset_blue;
 /// use photon_rs::native::open_image;
 ///
-/// let mut img = open_image("img.jpg");
+/// let mut img = open_image("img.jpg").expect("File should open");
 /// offset_blue(&mut img, 40_u32);
 /// ```
 #[wasm_bindgen]
@@ -116,15 +116,15 @@ pub fn offset_blue(img: &mut PhotonImage, offset_amt: u32) {
 ///
 /// # Arguments
 /// * `img` - A PhotonImage that contains a view into the image.
-/// * `offset` - The offset is added to the pixels in the image.  
+/// * `offset` - The offset is added to the pixels in the image.
 /// # Example
 ///
-/// ```
+/// ```no_run
 /// // For example, to add a 30-pixel offset to both the red and blue channels:
 /// use photon_rs::effects::multiple_offsets;
 /// use photon_rs::native::open_image;
 ///
-/// let mut img = open_image("img.jpg");
+/// let mut img = open_image("img.jpg").expect("File should open");
 /// multiple_offsets(&mut img, 30_u32, 0_usize, 2_usize);
 /// ```
 #[wasm_bindgen]
@@ -287,12 +287,12 @@ pub fn halftone(mut photon_image: PhotonImage) {
 /// * `img` - A PhotonImage that contains a view into the image.
 /// # Example
 ///
-/// ```
+/// ```no_run
 /// // For example, to add a primary colour effect to an image of type `DynamicImage`:
 /// use photon_rs::effects::primary;
 /// use photon_rs::native::open_image;
 ///
-/// let mut img = open_image("img.jpg");
+/// let mut img = open_image("img.jpg").expect("File should open");
 /// primary(&mut img);
 /// ```
 #[wasm_bindgen]
@@ -334,12 +334,12 @@ pub fn primary(img: &mut PhotonImage) {
 /// * `img` - A PhotonImage that contains a view into the image.
 /// # Example
 ///
-/// ```
+/// ```no_run
 /// // For example, to colorize an image of type `PhotonImage`:
 /// use photon_rs::effects::colorize;
 /// use photon_rs::native::open_image;
 ///
-/// let mut img = open_image("img.jpg");
+/// let mut img = open_image("img.jpg").expect("File should open");
 /// colorize(&mut img);
 /// ```
 #[wasm_bindgen]
@@ -439,12 +439,12 @@ pub fn colorize(mut photon_image: &mut PhotonImage) {
 /// * `img` - A PhotonImage that contains a view into the image.
 /// # Example
 ///
-/// ```
+/// ```no_run
 /// // For example, to colorize an image of type `PhotonImage`:
 /// use photon_rs::effects::solarize;
 /// use photon_rs::native::open_image;
 ///
-/// let mut img = open_image("img.jpg");
+/// let mut img = open_image("img.jpg").expect("File should open");
 /// solarize(&mut img);
 /// ```
 #[wasm_bindgen]
@@ -466,13 +466,13 @@ pub fn solarize(photon_image: &mut PhotonImage) {
 /// * `img` - A PhotonImage that contains a view into the image.
 /// # Example
 ///
-/// ```
+/// ```no_run
 /// // For example, to solarize "retimg" an image of type `PhotonImage`:
 /// use photon_rs::effects::solarize_retimg;
 /// use photon_rs::native::open_image;
 /// use photon_rs::PhotonImage;
 ///
-/// let img = open_image("img.jpg");
+/// let img = open_image("img.jpg").expect("File should open");
 /// let result: PhotonImage = solarize_retimg(&img);
 /// ```
 #[wasm_bindgen]
@@ -500,11 +500,11 @@ pub fn solarize_retimg(photon_image: &PhotonImage) -> PhotonImage {
 /// * `brightness` - A u8 to add to the brightness.
 /// # Example
 ///
-/// ```
+/// ```no_run
 /// use photon_rs::effects::inc_brightness;
 /// use photon_rs::native::open_image;
 ///
-/// let mut img = open_image("img.jpg");
+/// let mut img = open_image("img.jpg").expect("File should open");
 /// inc_brightness(&mut img, 10_u8);
 /// ```
 #[wasm_bindgen]
@@ -543,11 +543,11 @@ pub fn inc_brightness(photon_image: &mut PhotonImage, brightness: u8) {
 /// clamp results if passed factor is out of range.
 /// # Example
 ///
-/// ```
+/// ```no_run
 /// use photon_rs::effects::adjust_contrast;
 /// use photon_rs::native::open_image;
 ///
-/// let mut img = open_image("img.jpg");
+/// let mut img = open_image("img.jpg").expect("File should open");
 /// adjust_contrast(&mut img, 30_f32);
 /// ```
 #[wasm_bindgen]
@@ -588,12 +588,12 @@ pub fn adjust_contrast(mut photon_image: &mut PhotonImage, contrast: f32) {
 /// * `b_offset` - The amount the B channel should be incremented by.
 /// # Example
 ///
-/// ```
+/// ```no_run
 /// // For example, to tint an image of type `PhotonImage`:
 /// use photon_rs::effects::tint;
 /// use photon_rs::native::open_image;
 ///
-/// let mut img = open_image("img.jpg");
+/// let mut img = open_image("img.jpg").expect("File should open");
 /// tint(&mut img, 10_u32, 20_u32, 15_u32);
 /// ```
 ///

--- a/crate/src/filters.rs
+++ b/crate/src/filters.rs
@@ -14,11 +14,11 @@ use wasm_bindgen::prelude::*;
 /// * `img` - A PhotonImage.
 /// # Example
 ///
-/// ```
+/// ```no_run
 /// use photon_rs::filters::neue;
 /// use photon_rs::native::open_image;
 ///
-/// let mut img = open_image("img.jpg");
+/// let mut img = open_image("img.jpg").expect("File should open");
 /// neue(&mut img);
 /// ```
 #[wasm_bindgen]
@@ -39,11 +39,11 @@ pub fn neue(photon_image: &mut PhotonImage) {
 /// * `img` - A PhotonImage.
 /// # Example
 ///
-/// ```
+/// ```no_run
 /// use photon_rs::filters::lix;
 /// use photon_rs::native::open_image;
 ///
-/// let mut img = open_image("img.jpg");
+/// let mut img = open_image("img.jpg").expect("File should open");
 /// lix(&mut img);
 /// ```
 #[wasm_bindgen]
@@ -65,11 +65,11 @@ pub fn lix(photon_image: &mut PhotonImage) {
 /// * `img` - A PhotonImage.
 /// # Example
 ///
-/// ```
+/// ```no_run
 /// use photon_rs::filters::ryo;
 /// use photon_rs::native::open_image;
 ///
-/// let mut img = open_image("img.jpg");
+/// let mut img = open_image("img.jpg").expect("File should open");
 /// ryo(&mut img);
 /// ```
 #[wasm_bindgen]
@@ -107,12 +107,12 @@ pub fn ryo(photon_image: &mut PhotonImage) {
 /// * `filter_name` - The filter's name. Choose from the selection above, eg: "oceanic"
 /// # Example
 ///
-/// ```
+/// ```no_run
 /// // For example, to add a filter called "vintage" to an image:
 /// use photon_rs::filters::filter;
 /// use photon_rs::native::open_image;
 ///
-/// let mut img = open_image("img.jpg");
+/// let mut img = open_image("img.jpg").expect("File should open");
 /// filter(&mut img, "vintage");
 /// ```
 #[wasm_bindgen]
@@ -162,11 +162,11 @@ pub fn filter(img: &mut PhotonImage, filter_name: &str) {
 /// * `img` - A PhotonImage.
 /// # Example
 ///
-/// ```
+/// ```no_run
 /// use photon_rs::filters::lofi;
 /// use photon_rs::native::open_image;
 ///
-/// let mut img = open_image("img.jpg");
+/// let mut img = open_image("img.jpg").expect("File should open");
 /// lofi(&mut img);
 /// ```
 #[wasm_bindgen]
@@ -181,11 +181,11 @@ pub fn lofi(img: &mut PhotonImage) {
 /// * `img` - A PhotonImage.
 /// # Example
 ///
-/// ```
+/// ```no_run
 /// use photon_rs::filters::pastel_pink;
 /// use photon_rs::native::open_image;
 ///
-/// let mut img = open_image("img.jpg");
+/// let mut img = open_image("img.jpg").expect("File should open");
 /// pastel_pink(&mut img);
 /// ```
 #[wasm_bindgen]
@@ -201,11 +201,11 @@ pub fn pastel_pink(img: &mut PhotonImage) {
 /// * `img` - A PhotonImage.
 /// # Example
 ///
-/// ```
+/// ```no_run
 /// use photon_rs::filters::golden;
 /// use photon_rs::native::open_image;
 ///
-/// let mut img = open_image("img.jpg");
+/// let mut img = open_image("img.jpg").expect("File should open");
 /// golden(&mut img);
 /// ```
 #[wasm_bindgen]
@@ -221,11 +221,11 @@ pub fn golden(img: &mut PhotonImage) {
 /// * `img` - A PhotonImage.
 /// # Example
 ///
-/// ```
+/// ```no_run
 /// use photon_rs::filters::cali;
 /// use photon_rs::native::open_image;
 ///
-/// let mut img = open_image("img.jpg");
+/// let mut img = open_image("img.jpg").expect("File should open");
 /// cali(&mut img);
 /// ```
 #[wasm_bindgen]
@@ -241,11 +241,11 @@ pub fn cali(img: &mut PhotonImage) {
 /// * `img` - A PhotonImage.
 /// # Example
 ///
-/// ```
+/// ```no_run
 /// use photon_rs::filters::dramatic;
 /// use photon_rs::native::open_image;
 ///
-/// let mut img = open_image("img.jpg");
+/// let mut img = open_image("img.jpg").expect("File should open");
 /// dramatic(&mut img);
 /// ```
 #[wasm_bindgen]
@@ -260,11 +260,11 @@ pub fn dramatic(img: &mut PhotonImage) {
 /// * `img` - A PhotonImage.
 /// # Example
 ///
-/// ```
+/// ```no_run
 /// use photon_rs::filters::firenze;
 /// use photon_rs::native::open_image;
 ///
-/// let mut img = open_image("img.jpg");
+/// let mut img = open_image("img.jpg").expect("File should open");
 /// firenze(&mut img);
 /// ```
 #[wasm_bindgen]
@@ -282,11 +282,11 @@ pub fn firenze(img: &mut PhotonImage) {
 /// * `img` - A PhotonImage.
 /// # Example
 ///
-/// ```
+/// ```no_run
 /// use photon_rs::filters::obsidian;
 /// use photon_rs::native::open_image;
 ///
-/// let mut img = open_image("img.jpg");
+/// let mut img = open_image("img.jpg").expect("File should open");
 /// obsidian(&mut img);
 /// ```
 #[wasm_bindgen]

--- a/crate/src/lib.rs
+++ b/crate/src/lib.rs
@@ -14,7 +14,7 @@
 //! - **Blending**: Blend images together using 10 different techniques, change image backgrounds.
 //!
 //! ## Example
-//! ```rust
+//! ```no_run
 //! extern crate photon_rs;
 //!
 //! use photon_rs::channels::alter_red_channel;
@@ -22,10 +22,10 @@
 //!
 //! fn main() {
 //!     // Open the image (a PhotonImage is returned)
-//!     let mut img = open_image("img.jpg");
+//!     let mut img = open_image("img.jpg").expect("File should open");
 //!     // Apply a filter to the pixels
 //!     alter_red_channel(&mut img, 25_i16);
-//!     save_image(img, "raw_image.jpg");
+//!     save_image(img, "raw_image.jpg").expect("File should be saved");
 //! }
 //! ```
 //!

--- a/crate/src/monochrome.rs
+++ b/crate/src/monochrome.rs
@@ -19,12 +19,12 @@ use crate::iter::ImageIterator;
 ///
 /// # Example
 ///
-/// ```
+/// ```no_run
 /// // For example, to apply a monochrome effect to an image:
 /// use photon_rs::monochrome::monochrome;
 /// use photon_rs::native::open_image;
 ///
-/// let mut img = open_image("img.jpg");
+/// let mut img = open_image("img.jpg").expect("File should open");
 /// monochrome(&mut img, 40_u32, 50_u32, 100_u32);
 /// ```
 ///
@@ -68,12 +68,12 @@ pub fn monochrome(img: &mut PhotonImage, r_offset: u32, g_offset: u32, b_offset:
 /// * `photon_image` - A PhotonImage.
 /// # Example
 ///
-/// ```
+/// ```no_run
 /// // For example, to sepia an image of type `PhotonImage`:
 /// use photon_rs::monochrome::sepia;
 /// use photon_rs::native::open_image;
 ///
-/// let mut img = open_image("img.jpg");
+/// let mut img = open_image("img.jpg").expect("File should open");
 /// sepia(&mut img);
 /// ```
 ///
@@ -112,12 +112,12 @@ pub fn sepia(img: &mut PhotonImage) {
 
 /// # Example
 ///
-/// ```
+/// ```no_run
 /// // For example, to convert an image of type `PhotonImage` to grayscale:
 /// use photon_rs::monochrome::grayscale;
 /// use photon_rs::native::open_image;
 ///
-/// let mut img = open_image("img.jpg");
+/// let mut img = open_image("img.jpg").expect("File should open");
 /// grayscale(&mut img);
 /// ```
 #[wasm_bindgen]
@@ -146,12 +146,12 @@ pub fn grayscale(img: &mut PhotonImage) {
 
 /// # Example
 ///
-/// ```
+/// ```no_run
 /// // For example, to convert an image of type `PhotonImage` to grayscale with a human corrected factor:
 /// use photon_rs::monochrome::grayscale_human_corrected;
 /// use photon_rs::native::open_image;
 ///
-/// let mut img = open_image("img.jpg");
+/// let mut img = open_image("img.jpg").expect("File should open");
 /// grayscale_human_corrected(&mut img);
 /// ```
 #[wasm_bindgen]
@@ -178,12 +178,12 @@ pub fn grayscale_human_corrected(img: &mut PhotonImage) {
 
 /// # Example
 ///
-/// ```
+/// ```no_run
 /// // For example, to desaturate an image:
 /// use photon_rs::monochrome::desaturate;
 /// use photon_rs::native::open_image;
 ///
-/// let mut img = open_image("img.jpg");
+/// let mut img = open_image("img.jpg").expect("File should open");
 /// desaturate(&mut img);
 /// ```
 #[wasm_bindgen]
@@ -214,12 +214,12 @@ pub fn desaturate(img: &mut PhotonImage) {
 
 /// # Example
 ///
-/// ```
+/// ```no_run
 /// // For example, to decompose an image with min decomposition:
 /// use photon_rs::monochrome::decompose_min;
 /// use photon_rs::native::open_image;
 ///
-/// let mut img = open_image("img.jpg");
+/// let mut img = open_image("img.jpg").expect("File should open");
 /// decompose_min(&mut img);
 /// ```
 #[wasm_bindgen]
@@ -250,12 +250,12 @@ pub fn decompose_min(img: &mut PhotonImage) {
 
 /// # Example
 ///
-/// ```
+/// ```no_run
 /// // For example, to decompose an image with max decomposition:
 /// use photon_rs::monochrome::decompose_max;
 /// use photon_rs::native::open_image;
 ///
-/// let mut img = open_image("img.jpg");
+/// let mut img = open_image("img.jpg").expect("File should open");
 /// decompose_max(&mut img);
 /// ```
 #[wasm_bindgen]
@@ -287,12 +287,12 @@ pub fn decompose_max(img: &mut PhotonImage) {
 
 /// # Example
 ///
-/// ```
+/// ```no_run
 /// // For example, to limit an image to four shades of gray only:
 /// use photon_rs::monochrome::grayscale_shades;
 /// use photon_rs::native::open_image;
 ///
-/// let mut img = open_image("img.jpg");
+/// let mut img = open_image("img.jpg").expect("File should open");
 /// grayscale_shades(&mut img, 4_u8);
 /// ```
 #[wasm_bindgen]
@@ -325,11 +325,11 @@ pub fn grayscale_shades(mut photon_image: &mut PhotonImage, num_shades: u8) {
 
 /// # Example
 ///
-/// ```
+/// ```no_run
 /// use photon_rs::monochrome::r_grayscale;
 /// use photon_rs::native::open_image;
 ///
-/// let mut img = open_image("img.jpg");
+/// let mut img = open_image("img.jpg").expect("File should open");
 /// r_grayscale(&mut img);
 /// ```
 #[wasm_bindgen]
@@ -344,11 +344,11 @@ pub fn r_grayscale(photon_image: &mut PhotonImage) {
 
 /// # Example
 ///
-/// ```
+/// ```no_run
 /// use photon_rs::monochrome::g_grayscale;
 /// use photon_rs::native::open_image;
 ///
-/// let mut img = open_image("img.jpg");
+/// let mut img = open_image("img.jpg").expect("File should open");
 /// g_grayscale(&mut img);
 /// ```
 #[wasm_bindgen]
@@ -363,11 +363,11 @@ pub fn g_grayscale(photon_image: &mut PhotonImage) {
 
 /// # Example
 ///
-/// ```
+/// ```no_run
 /// use photon_rs::monochrome::b_grayscale;
 /// use photon_rs::native::open_image;
 ///
-/// let mut img = open_image("img.jpg");
+/// let mut img = open_image("img.jpg").expect("File should open");
 /// b_grayscale(&mut img);
 /// ```
 #[wasm_bindgen]
@@ -383,11 +383,11 @@ pub fn b_grayscale(photon_image: &mut PhotonImage) {
 
 /// # Example
 /// To grayscale using only values from the Red channel:
-/// ```
+/// ```no_run
 /// use photon_rs::monochrome::single_channel_grayscale;
 /// use photon_rs::native::open_image;
 ///
-/// let mut img = open_image("img.jpg");
+/// let mut img = open_image("img.jpg").expect("File should open");
 /// single_channel_grayscale(&mut img, 0_usize);
 /// ```
 #[wasm_bindgen]
@@ -415,12 +415,12 @@ pub fn single_channel_grayscale(mut photon_image: &mut PhotonImage, channel: usi
 /// * `threshold` - The amount the image should be thresholded by from 0 to 255.
 /// # Example
 ///
-/// ```
+/// ```no_run
 /// // For example, to threshold an image of type `PhotonImage`:
 /// use photon_rs::monochrome::threshold;
 /// use photon_rs::native::open_image;
 ///
-/// let mut img = open_image("img.jpg");
+/// let mut img = open_image("img.jpg").expect("File should open");
 /// threshold(&mut img, 30_u32);
 /// ```
 #[wasm_bindgen]

--- a/crate/src/multiple.rs
+++ b/crate/src/multiple.rs
@@ -18,13 +18,13 @@ use wasm_bindgen::prelude::*;
 /// * `y` - The y coordinate where the watermark's top corner should be positioned.
 /// # Example
 ///
-/// ```
+/// ```no_run
 /// // For example, to add a watermark to an image at x: 30, y: 40:
 /// use photon_rs::multiple::watermark;
 /// use photon_rs::native::open_image;
 ///
-/// let mut img = open_image("img.jpg");
-/// let water_mark = open_image("watermark.jpg");
+/// let mut img = open_image("img.jpg").expect("File should open");
+/// let water_mark = open_image("watermark.jpg").expect("File should open");
 /// watermark(&mut img, &water_mark, 30_u32, 40_u32);
 /// ```
 #[wasm_bindgen]
@@ -49,13 +49,13 @@ pub fn watermark(mut img: &mut PhotonImage, watermark: &PhotonImage, x: u32, y: 
 /// * `blend_mode` - The blending mode to use. See above for complete list of blend modes available.
 /// # Example
 ///
-/// ```
+/// ```no_run
 /// // For example, to blend two images with the `multiply` blend mode:
 /// use photon_rs::multiple::blend;
 /// use photon_rs::native::open_image;
 ///
-/// let mut img = open_image("img.jpg");
-/// let img2 = open_image("img2.jpg");
+/// let mut img = open_image("img.jpg").expect("File should open");
+/// let img2 = open_image("img2.jpg").expect("File should open");
 /// blend(&mut img, &img2, "multiply");
 /// ```
 #[wasm_bindgen]
@@ -118,8 +118,8 @@ pub fn blend(
 
 // #[wasm_bindgen]
 // pub fn blend_img_browser(
-//     source_canvas: HtmlCanvasElement, 
-//     overlay_img: HtmlImageElement, 
+//     source_canvas: HtmlCanvasElement,
+//     overlay_img: HtmlImageElement,
 //     blend_mode: &str) {
 
 //     let ctx = source_canvas
@@ -130,7 +130,7 @@ pub fn blend(
 //     ctx.draw_image_with_html_image_element(&overlay_img, 0.0, 0.0);
 //     ctx.set_global_composite_operation(blend_mode);
 //     ctx.set_global_alpha(1.0);
-    
+
 // }
 
 
@@ -142,15 +142,15 @@ pub fn blend(
 /// * `background_color` - The RGB value of the background, which should be replaced.
 /// # Example
 ///
-/// ```
+/// ```no_run
 /// // For example, to replace the background of ImageA (which is RGB value 20, 40, 60) with the background of ImageB:
 /// use photon_rs::Rgb;
 /// use photon_rs::multiple::replace_background;
 /// use photon_rs::native::open_image;
 ///
 /// let rgb = Rgb::new(20_u8, 40_u8, 60_u8);
-/// let mut img = open_image("img.jpg");
-/// let img2 = open_image("img2.jpg");
+/// let mut img = open_image("img.jpg").expect("File should open");
+/// let img2 = open_image("img2.jpg").expect("File should open");
 /// replace_background(&mut img, &img2, rgb);
 /// ```
 pub fn replace_background(

--- a/crate/src/native.rs
+++ b/crate/src/native.rs
@@ -28,12 +28,11 @@ pub enum SaveError {
 /// * `img_path` - Path to the image you wish to edit.
 ///
 /// # Example
-/// ```
-/// // For example:
+/// ```no_run
 /// use photon_rs::native::open_image;
 ///
 /// // Open the image. A PhotonImage is returned.
-/// let img = open_image("img.jpg");
+/// let img = open_image("img.jpg").expect("File should open");
 ///
 /// // ... image editing functionality here ...
 /// ```
@@ -58,8 +57,7 @@ pub fn open_image(img_path: &str) -> Result<PhotonImage, OpenError> {
 /// * `img_path` - Path for the outputted image.
 ///
 /// # Example
-/// ```
-/// // For example:
+/// ```no_run
 /// use photon_rs::native::{save_image, open_image};
 ///
 /// let img = open_image("img.jpg").expect("File should open");

--- a/crate/src/noise.rs
+++ b/crate/src/noise.rs
@@ -20,13 +20,13 @@ use crate::iter::ImageIterator;
 ///
 /// # Example
 ///
-/// ```
+/// ```no_run
 /// // For example:
 /// use photon_rs::native::open_image;
 /// use photon_rs::noise::add_noise_rand;
 /// use photon_rs::PhotonImage;
 ///
-/// let img = open_image("img.jpg");
+/// let img = open_image("img.jpg").expect("File should open");
 /// let result: PhotonImage = add_noise_rand(img);
 /// ```
 pub fn add_noise_rand(mut photon_image: PhotonImage) -> PhotonImage {
@@ -57,12 +57,12 @@ pub fn add_noise_rand(mut photon_image: PhotonImage) -> PhotonImage {
 ///
 /// # Example
 ///
-/// ```
+/// ```no_run
 /// // For example, to add pink-tinted noise to an image:
 /// use photon_rs::native::open_image;
 /// use photon_rs::noise::pink_noise;
 ///
-/// let mut img = open_image("img.jpg");
+/// let mut img = open_image("img.jpg").expect("File should open");
 /// pink_noise(&mut img);
 /// ```
 pub fn pink_noise(mut photon_image: &mut PhotonImage) {

--- a/crate/src/text.rs
+++ b/crate/src/text.rs
@@ -25,13 +25,14 @@ use crate::iter::ImageIterator;
 /// * `y` - y-coordinate of where first letter's 1st pixel should be drawn.
 ///
 /// # Example
-/// ```
+///
+/// ```no_run
 /// // For example to draw the string "Welcome to Photon!" at 10, 10:
 /// use photon_rs::native::open_image;
 /// use photon_rs::text::draw_text_with_border;
 ///
 /// // Open the image. A PhotonImage is returned.
-/// let mut img = open_image("img.jpg");
+/// let mut img = open_image("img.jpg").expect("File should open");
 /// draw_text_with_border(&mut img, "Welcome to Photon!", 10_u32, 10_u32);
 /// ```
 #[wasm_bindgen]
@@ -102,13 +103,14 @@ pub fn draw_text_with_border(
 /// * `y` - y-coordinate of where first letter's 1st pixel should be drawn.
 ///
 /// # Example
-/// ```
+///
+/// ```no_run
 /// // For example to draw the string "Welcome to Photon!" at 10, 10:
 /// use photon_rs::native::open_image;
 /// use photon_rs::text::draw_text;
 ///
 /// // Open the image. A PhotonImage is returned.
-/// let mut img = open_image("img.jpg");
+/// let mut img = open_image("img.jpg").expect("File should open");
 /// draw_text(&mut img, "Welcome to Photon!", 10_u32, 10_u32);
 /// ```
 #[wasm_bindgen]

--- a/crate/src/transform.rs
+++ b/crate/src/transform.rs
@@ -18,15 +18,15 @@ use self::image::{DynamicImage, GenericImage};
 /// # Arguments
 /// * `img` - A PhotonImage.
 ///
-/// ## Example
+/// # Example
 ///
-/// ```
+/// ```no_run
 /// // For example, to crop an image at (0, 0) to (500, 800)
 /// use photon_rs::native::{open_image, save_image};
 /// use photon_rs::transform::crop;
 /// use photon_rs::PhotonImage;
 ///
-/// let mut img = open_image("img.jpg");
+/// let mut img = open_image("img.jpg").expect("File should open");
 /// let cropped_img: PhotonImage = crop(&mut img, 0_u32, 0_u32, 500_u32, 800_u32);
 /// // Write the contents of this image in JPG format.
 /// save_image(cropped_img, "cropped_image.jpg");
@@ -72,7 +72,7 @@ pub fn crop_img_browser(source_canvas: HtmlCanvasElement, width: f64, height: f6
     .unwrap()
     .dyn_into::<web_sys::CanvasRenderingContext2d>().unwrap();
 
-    ctx.draw_image_with_html_canvas_element_and_sw_and_sh_and_dx_and_dy_and_dw_and_dh(&source_canvas, 
+    ctx.draw_image_with_html_canvas_element_and_sw_and_sh_and_dx_and_dy_and_dw_and_dh(&source_canvas,
         left, top, width, height, 0.0, 0.0, width, height).unwrap();
 
     return dest_canvas;
@@ -83,14 +83,14 @@ pub fn crop_img_browser(source_canvas: HtmlCanvasElement, width: f64, height: f6
 /// # Arguments
 /// * `img` - A PhotonImage.
 ///
-/// ## Example
+/// # Example
 ///
-/// ```
+/// ```no_run
 /// // For example, to flip an image horizontally:
 /// use photon_rs::native::open_image;
 /// use photon_rs::transform::fliph;
 ///
-/// let mut img = open_image("img.jpg");
+/// let mut img = open_image("img.jpg").expect("File should open");
 /// fliph(&mut img);
 /// ```
 #[wasm_bindgen]
@@ -116,14 +116,14 @@ pub fn fliph(photon_image: &mut PhotonImage) {
 /// # Arguments
 /// * `img` - A PhotonImage.
 ///
-/// ## Example
+/// # Example
 ///
-/// ```
+/// ```no_run
 /// // For example, to flip an image vertically:
 /// use photon_rs::native::open_image;
 /// use photon_rs::transform::flipv;
 ///
-/// let mut img = open_image("img.jpg");
+/// let mut img = open_image("img.jpg").expect("File should open");
 /// flipv(&mut img);
 /// ```
 #[wasm_bindgen]
@@ -260,15 +260,15 @@ pub fn resize(
 /// * `width` - New width.
 /// * `height` - New height.
 ///
-/// ## Example
+/// # Example
 ///
-/// ```
+/// ```no_run
 /// // For example, resize image using seam carver:
 /// use photon_rs::native::open_image;
 /// use photon_rs::transform::seam_carve;
 /// use photon_rs::PhotonImage;
 ///
-/// let img = open_image("img.jpg");
+/// let img = open_image("img.jpg").expect("File should open");
 /// let result: PhotonImage = seam_carve(&img, 100_u32, 100_u32);
 /// ```
 #[wasm_bindgen]

--- a/photon-docs/docs/native-tutorial.md
+++ b/photon-docs/docs/native-tutorial.md
@@ -1,9 +1,9 @@
 # Native Tutorial
 
-In this tutorial, we're going to write a program that resizes an image and applies a filter to it. 
-You'll get a feel for how to use Photon, and will be able to build upon this to use Photon in your own projects. 
+In this tutorial, we're going to write a program that resizes an image and applies a filter to it.
+You'll get a feel for how to use Photon, and will be able to build upon this to use Photon in your own projects.
 
-## Getting Started 
+## Getting Started
 Ensuring you have Rust installed, create a new Rust project:
 
 ```bash
@@ -24,7 +24,7 @@ Add Photon as a dependency to your project:
 Your Cargo.toml should look like this:
 
 ##### Cargo.toml
-    #!toml 
+    #!toml
     [package]
     name = "photon-demo"
     version = "0.1.0"
@@ -38,7 +38,7 @@ Your Cargo.toml should look like this:
 
 
 ## Writing The Program
-Next up, open your `bin.rs` file. You'll find a sample function in there, remove that since we won't be using it. 
+Next up, open your `bin.rs` file. You'll find a sample function in there, remove that since we won't be using it.
 
 #### Open An Image
 
@@ -50,38 +50,38 @@ To open an image:
     use photon_rs::native::{open_image};
 
     fn main() {
-        let mut img = open_image("image.jpg");
+        let mut img = open_image("image.jpg").expect("File should open");
     }
 
 #### Apply a Filter Effect
 
-To apply a filter effect to the opened image, we need to pass in our image and a filter name. 
+To apply a filter effect to the opened image, we need to pass in our image and a filter name.
 
     #!rust
     photon_rs::filters::filter(&mut img, "twenties");
 
 Notice that we're passing a mutable reference to the image. This allows the function to modify the image, rather than return a new image.
 There are a variety of filter effects we can pass. Once you get the program compiled, try passing in "radio" instead of the filter above.
-For a full list, see the documentation. 
+For a full list, see the documentation.
 
 #### Save To The Filesystem
 Then, to write the image to the filesystem:
 
     #!rust
-    save_image(img, "new_image.jpg");
+    save_image(img, "new_image.jpg").expect("File should be saved");
 
 Notice here we're saving it as a JPG image, but we could also save it as a PNG or a different output format, by including a different file extension.
 
 #### Get An Image
-Next up, you'll need an image to work with. You can use an image from your own collection, or try out the images available at [Unsplash](https://unsplash.com/), 
+Next up, you'll need an image to work with. You can use an image from your own collection, or try out the images available at [Unsplash](https://unsplash.com/),
 which are also available in the Public Domain.
 
 Name it `image.jpg`, and save it in the same directory as your rust project.
 
-### Final Program 
+### Final Program
 The final code looks like this:
 
-##### bin.rs 
+##### bin.rs
     #!rust
     extern crate photon_rs;
     use photon_rs::{filters};
@@ -89,28 +89,28 @@ The final code looks like this:
 
     fn main() {
         // Open the image (a PhotonImage is returned)
-        let mut img = open_image("image.jpg");
+        let mut img = open_image("image.jpg").expect("File should open");
 
         // Apply a filter to the pixels
         filters::filter(&mut img, "twenties");
 
         // Write the new image to the filesystem.
-        save_image(img, "new_image.jpg");
+        save_image(img, "new_image.jpg").expect("File should be saved");
 
     }
 
 ##### Run The Code
-To run the program in release mode, run: 
+To run the program in release mode, run:
 
 ```bash
-cargo run --release 
+cargo run --release
 ```
 
 !!! warning
-    Make sure you run in **release** mode for optimum performance, by adding the --release flag to your command. 
+    Make sure you run in **release** mode for optimum performance, by adding the --release flag to your command.
     Otherwise, performance will be greatly affected.
 
-#### Bonus: Add Timing 
+#### Bonus: Add Timing
 If you'd like to find out how long it takes to process your image, you can add some code to capture this.
 
 Add the `time` dependency to your Cargo.toml:
@@ -130,14 +130,14 @@ Then in your code:
 
     fn main() {
         // Open the image (a PhotonImage is returned)
-        let mut img = open_image("image.jpg");
+        let mut img = open_image("image.jpg").expect("File should open");
 
         // Start time
         let start = PreciseTime::now();
 
-        // Process image 
+        // Process image
         photon_rs::channels::alter_channel(&mut img, 1, -20);
-        save_image(img, "raw_image.png");    
+        save_image(img, "raw_image.png").expect("File should be saved");
 
         // Output time taken.
         let end = PreciseTime::now();

--- a/photon-docs/docs/using-photon-natively.md
+++ b/photon-docs/docs/using-photon-natively.md
@@ -8,7 +8,7 @@ Add Photon as a dependency to your project's Cargo.toml:
 photon-rs = "0.2.0"
 ```
 
-## Open an Image 
+## Open an Image
 To open an image:
 
 ##### bin.rs
@@ -16,24 +16,24 @@ To open an image:
     extern crate photon_rs;
     use photon_rs::native::{open_image};
     fn main() {
-        let mut img = open_image("image.jpg");
+        let mut img = open_image("image.jpg").expect("File should open");
     }
 
 ## Process The Image
-To apply a filter effect to the opened image, we need to pass in our image and a filter name. 
+To apply a filter effect to the opened image, we need to pass in our image and a filter name.
 
     #!rust
     photon_rs::filters::filter(&mut img, "twenties");
 
 Notice that we're passing a mutable reference to the image. This allows the function to modify the image, rather than return a new image.
 There are a variety of filter effects we can pass. Once you get the program compiled, try passing in "radio" instead of the filter above.
-For a full list, see the [documentation](https://docs.rs/photon-rs). 
+For a full list, see the [documentation](https://docs.rs/photon-rs).
 
 ## Write to the Filesystem
 Then, to write the image to the filesystem:
 
     #!rust
-    save_image(img, "new_image.jpg");
+    save_image(img, "new_image.jpg").expect("File should be saved");
 
 Notice here we're saving it as a JPG image, but we could also save it as a PNG or a different output format, by including a different file extension.
 
@@ -47,10 +47,10 @@ This program adds a sepia effect to an image:
 
     fn main() {
         // Open the image (a PhotonImage is returned)
-        let mut img = open_image("image.jpg");
+        let mut img = open_image("image.jpg").expect("File should open");
 
         // Apply a sepia effect to the image.
         monochrome::sepia(&mut img);
 
-        save_image(img, "raw_image.png");    
+        save_image(img, "raw_image.png").expect("File should be saved");
     }


### PR DESCRIPTION
For `open_image` the underlying `image` crate actually returns an `enum ImageError` (https://docs.rs/image/0.23.10/image/error/enum.ImageError.html) with errors ranging from an IO error to size, support, etc.

For `save_image` I thought it's more appropriate to have an enum and ask if the `Option` from the `ImageBuffer::from_vec` call should be still `unwrap()`ed or handled with an error as it is now.

1. `struct OpenError` - with `#[transparent]` the `source` of the Error & `impl Display` are delegated to `ImageError` + an implementation of `From<ImageError>` with `#[from]`
2. `enum SaveError` - with `transparent` the `source` of the Error & `impl Display` are delegated to the `std::io::Error`


I am not sure if they should be left like this so feedback is welcome.

### TODOs:

1. Find all places of `open_image` and handle the `Result`
2. Find all places of `save_image` and handle the `Result`
3. Make the doc comments compile. Currently the `img.jpg` file doesn't exist and all the doc tests fail. How should we add this image and is there a test image we can use?
