### PR TITLE
Fix: Halftone consisitency

### DIFF
--- a/crate/Cargo.toml
+++ b/crate/Cargo.toml
@@ -18,11 +18,11 @@ homepage = "https://silvia-odwyer.github.io/photon/"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-image="0.21.1"
+image="0.23.10"
 palette="0.5.0"
 rand="0.7.2"
 num="0.2.0"
-imageproc="0.18.0"
+imageproc="0.21.0"
 rusttype="0.7.6"
 base64="0.11.0"
 time="0.2.1"

--- a/crate/Cargo.toml
+++ b/crate/Cargo.toml
@@ -18,11 +18,11 @@ homepage = "https://silvia-odwyer.github.io/photon/"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-image="0.23.10"
+image="0.21.1"
 palette="0.5.0"
 rand="0.7.2"
 num="0.2.0"
-imageproc="0.21.0"
+imageproc="0.18.0"
 rusttype="0.7.6"
 base64="0.11.0"
 time="0.2.1"

--- a/crate/src/effects.rs
+++ b/crate/src/effects.rs
@@ -165,7 +165,7 @@ pub fn multiple_offsets(
 }
 
 /// Halftoning effect.
-pub fn halftone(mut photon_image: PhotonImage) {
+pub fn halftone(mut photon_image: &mut PhotonImage) {
     let mut img = helpers::dyn_image_from_raw(&photon_image);
     let (width, height) = img.dimensions();
 


### PR DESCRIPTION
This PR ensures that the `halftone` effect uses `&mut PhotonImage` instead of just `PhotonImage`