### PR TITLE
New Native Methods.

### DIFF
--- a/crate/src/channels.rs
+++ b/crate/src/channels.rs
@@ -1,13 +1,13 @@
 //! Channel manipulation.
 
-extern crate image;
+use image;
 
 use image::{GenericImage, GenericImageView};
 
-extern crate wasm_bindgen;
+use wasm_bindgen;
 use crate::helpers;
 use crate::{PhotonImage, Rgb};
-extern crate palette;
+use palette;
 use crate::channels::image::Pixel as OtherPixel;
 use crate::channels::palette::Hue;
 use crate::iter::ImageIterator;

--- a/crate/src/channels.rs
+++ b/crate/src/channels.rs
@@ -4,14 +4,14 @@ use image;
 
 use image::{GenericImage, GenericImageView};
 
-use wasm_bindgen;
-use crate::helpers;
-use crate::{PhotonImage, Rgb};
-use palette;
 use crate::channels::image::Pixel as OtherPixel;
 use crate::channels::palette::Hue;
+use crate::helpers;
 use crate::iter::ImageIterator;
+use crate::{PhotonImage, Rgb};
+use palette;
 use palette::{Lab, Lch, Saturate, Shade, Srgb, Srgba};
+use wasm_bindgen;
 use wasm_bindgen::prelude::*;
 
 /// Alter a select channel by incrementing or decrementing its value by a constant.

--- a/crate/src/channels.rs
+++ b/crate/src/channels.rs
@@ -1,17 +1,13 @@
 //! Channel manipulation.
 
-use image;
+use image::Pixel as OtherPixel;
 
 use image::{GenericImage, GenericImageView};
 
-use crate::channels::image::Pixel as OtherPixel;
-use crate::channels::palette::Hue;
 use crate::helpers;
 use crate::iter::ImageIterator;
 use crate::{PhotonImage, Rgb};
-use palette;
-use palette::{Lab, Lch, Saturate, Shade, Srgb, Srgba};
-use wasm_bindgen;
+use palette::{Hue, Lab, Lch, Saturate, Shade, Srgb, Srgba};
 use wasm_bindgen::prelude::*;
 
 /// Alter a select channel by incrementing or decrementing its value by a constant.
@@ -434,7 +430,6 @@ pub fn selective_hue_rotate(
             let px_data = img.get_pixel(x, y).channels();
             let color =
                 Srgba::new(px_data[0], px_data[1], px_data[2], 255).into_format();
-
             let hue_rotated_color = Lch::from(color).shift_hue(degrees);
 
             let final_color: Srgba =

--- a/crate/src/colour_spaces.rs
+++ b/crate/src/colour_spaces.rs
@@ -1,11 +1,11 @@
 //! Image manipulation effects in HSL, LCh and HSV.
 
-extern crate image;
-extern crate rand;
+use image;
+use rand;
 use crate::{helpers, PhotonImage, Rgb};
 use image::GenericImageView;
 use palette::{Hsl, Hsv, Hue, Lch, Saturate, Shade, Srgba};
-extern crate wasm_bindgen;
+use wasm_bindgen;
 use crate::iter::ImageIterator;
 use image::Pixel as ImagePixel;
 use wasm_bindgen::prelude::*;

--- a/crate/src/colour_spaces.rs
+++ b/crate/src/colour_spaces.rs
@@ -1,13 +1,12 @@
 //! Image manipulation effects in HSL, LCh and HSV.
 
-use image;
-use rand;
+use crate::iter::ImageIterator;
 use crate::{helpers, PhotonImage, Rgb};
+use image;
 use image::GenericImageView;
+use image::Pixel as ImagePixel;
 use palette::{Hsl, Hsv, Hue, Lch, Saturate, Shade, Srgba};
 use wasm_bindgen;
-use crate::iter::ImageIterator;
-use image::Pixel as ImagePixel;
 use wasm_bindgen::prelude::*;
 
 /// Apply gamma correction.

--- a/crate/src/colour_spaces.rs
+++ b/crate/src/colour_spaces.rs
@@ -2,11 +2,9 @@
 
 use crate::iter::ImageIterator;
 use crate::{helpers, PhotonImage, Rgb};
-use image;
 use image::GenericImageView;
 use image::Pixel as ImagePixel;
 use palette::{Hsl, Hsv, Hue, Lch, Saturate, Shade, Srgba};
-use wasm_bindgen;
 use wasm_bindgen::prelude::*;
 
 /// Apply gamma correction.

--- a/crate/src/conv.rs
+++ b/crate/src/conv.rs
@@ -1,8 +1,8 @@
 //! Convolution effects such as sharpening, blurs, sobel filters, etc.,
 
-use image;
 use crate::helpers;
 use crate::PhotonImage;
+use image;
 use image::DynamicImage::ImageRgba8;
 use wasm_bindgen::prelude::*;
 

--- a/crate/src/conv.rs
+++ b/crate/src/conv.rs
@@ -1,6 +1,6 @@
 //! Convolution effects such as sharpening, blurs, sobel filters, etc.,
 
-extern crate image;
+use image;
 use crate::helpers;
 use crate::PhotonImage;
 use image::DynamicImage::ImageRgba8;

--- a/crate/src/conv.rs
+++ b/crate/src/conv.rs
@@ -2,7 +2,6 @@
 
 use crate::helpers;
 use crate::PhotonImage;
-use image;
 use image::DynamicImage::ImageRgba8;
 use wasm_bindgen::prelude::*;
 

--- a/crate/src/effects.rs
+++ b/crate/src/effects.rs
@@ -1,17 +1,16 @@
 //! Special effects.
 
-use image;
-use image::{GenericImage, GenericImageView};
-use std::f64;
-use imageproc;
-use imageproc::drawing::draw_filled_rect_mut;
-use imageproc::rect::Rect;
-use rusttype;
 use crate::helpers;
 use crate::iter::ImageIterator;
 use crate::{PhotonImage, Rgb};
+use image;
 use image::Pixel;
 use image::Rgba;
+use image::{GenericImage, GenericImageView};
+use imageproc;
+use imageproc::drawing::draw_filled_rect_mut;
+use imageproc::rect::Rect;
+use std::f64;
 use wasm_bindgen::prelude::*;
 
 /// Adds an offset to the image by a certain number of pixels.

--- a/crate/src/effects.rs
+++ b/crate/src/effects.rs
@@ -1,12 +1,12 @@
 //! Special effects.
 
-extern crate image;
+use image;
 use image::{GenericImage, GenericImageView};
 use std::f64;
-extern crate imageproc;
+use imageproc;
 use imageproc::drawing::draw_filled_rect_mut;
 use imageproc::rect::Rect;
-extern crate rusttype;
+use rusttype;
 use crate::helpers;
 use crate::iter::ImageIterator;
 use crate::{PhotonImage, Rgb};

--- a/crate/src/effects.rs
+++ b/crate/src/effects.rs
@@ -3,11 +3,9 @@
 use crate::helpers;
 use crate::iter::ImageIterator;
 use crate::{PhotonImage, Rgb};
-use image;
 use image::Pixel;
 use image::Rgba;
 use image::{GenericImage, GenericImageView};
-use imageproc;
 use imageproc::drawing::draw_filled_rect_mut;
 use imageproc::rect::Rect;
 use std::f64;

--- a/crate/src/filters.rs
+++ b/crate/src/filters.rs
@@ -1,6 +1,6 @@
 //! Preset color filters.
 
-extern crate image;
+use image;
 use crate::colour_spaces;
 use crate::colour_spaces::mix_with_colour;
 use crate::effects::{adjust_contrast, inc_brightness};

--- a/crate/src/filters.rs
+++ b/crate/src/filters.rs
@@ -1,6 +1,5 @@
 //! Preset color filters.
 
-use image;
 use crate::colour_spaces;
 use crate::colour_spaces::mix_with_colour;
 use crate::effects::{adjust_contrast, inc_brightness};

--- a/crate/src/helpers.rs
+++ b/crate/src/helpers.rs
@@ -1,7 +1,7 @@
 //! Helper functions for converting between various formats
 
-extern crate base64;
-extern crate image;
+use base64;
+use image;
 use crate::{PhotonImage, Rgb};
 use image::{DynamicImage, ImageBuffer};
 extern crate wasm_bindgen;

--- a/crate/src/helpers.rs
+++ b/crate/src/helpers.rs
@@ -1,7 +1,6 @@
 //! Helper functions for converting between various formats
 
 use crate::{PhotonImage, Rgb};
-use image;
 use image::{DynamicImage, ImageBuffer};
 extern crate wasm_bindgen;
 use image::DynamicImage::ImageRgba8;

--- a/crate/src/helpers.rs
+++ b/crate/src/helpers.rs
@@ -1,8 +1,7 @@
 //! Helper functions for converting between various formats
 
-use base64;
-use image;
 use crate::{PhotonImage, Rgb};
+use image;
 use image::{DynamicImage, ImageBuffer};
 extern crate wasm_bindgen;
 use image::DynamicImage::ImageRgba8;

--- a/crate/src/monochrome.rs
+++ b/crate/src/monochrome.rs
@@ -1,9 +1,9 @@
 //! Monochrome-related effects and greyscaling/duotoning.
 
-use image;
 use crate::helpers;
 use crate::iter::ImageIterator;
 use crate::PhotonImage;
+use image;
 use image::Pixel;
 use image::{GenericImage, GenericImageView};
 use wasm_bindgen::prelude::*;

--- a/crate/src/monochrome.rs
+++ b/crate/src/monochrome.rs
@@ -1,6 +1,6 @@
 //! Monochrome-related effects and greyscaling/duotoning.
 
-extern crate image;
+use image;
 use crate::helpers;
 use crate::iter::ImageIterator;
 use crate::PhotonImage;

--- a/crate/src/monochrome.rs
+++ b/crate/src/monochrome.rs
@@ -3,7 +3,6 @@
 use crate::helpers;
 use crate::iter::ImageIterator;
 use crate::PhotonImage;
-use image;
 use image::Pixel;
 use image::{GenericImage, GenericImageView};
 use wasm_bindgen::prelude::*;

--- a/crate/src/multiple.rs
+++ b/crate/src/multiple.rs
@@ -1,6 +1,5 @@
 //! Image manipulation with multiple images, including adding watermarks, changing backgrounds, etc.,
 
-
 use crate::channels::color_sim;
 use crate::iter::ImageIterator;
 use crate::{helpers, GenericImage, PhotonImage, Rgb};

--- a/crate/src/multiple.rs
+++ b/crate/src/multiple.rs
@@ -1,7 +1,6 @@
 //! Image manipulation with multiple images, including adding watermarks, changing backgrounds, etc.,
 
-extern crate image;
-extern crate rand;
+
 use crate::channels::color_sim;
 use crate::iter::ImageIterator;
 use crate::{helpers, GenericImage, PhotonImage, Rgb};

--- a/crate/src/native.rs
+++ b/crate/src/native.rs
@@ -59,7 +59,7 @@ pub fn open_image(img_path: &str) -> Result<PhotonImage, OpenError> {
 /// use photon_rs::native::open_image_from_bytes;
 ///
 /// // Code to read a file to buffer. If you are reading from a file its better to use `open_image`
-/// let buffer = std::fs::read("file.png")?.as_slice();
+/// let buffer = std::fs::read("img.jpg").expect("File Should Open").as_slice();
 ///
 /// // Open the image. A PhotonImage is returned.
 /// let img = open_image_from_bytes(buffer).expect("File should open");
@@ -111,7 +111,7 @@ pub fn save_image(img: PhotonImage, img_path: &str) {
 ///
 /// let img = open_image("img.jpg").expect("File should open");
 /// // Save the image at a vec<u8>
-/// let byt = save_image_to_bytes(img);
+/// let byt = image_to_bytes(img);
 /// ```
 pub fn image_to_bytes(img: PhotonImage) -> Vec<u8> {
     let raw_pixels = img.raw_pixels;

--- a/crate/src/native.rs
+++ b/crate/src/native.rs
@@ -4,7 +4,7 @@
 use image;
 use image::DynamicImage::ImageRgba8;
 use image::{GenericImageView, ImageBuffer, ImageError};
-
+use std::io;
 // use wasm_bindgen::prelude::*;
 use crate::PhotonImage;
 use thiserror::Error;

--- a/crate/src/native.rs
+++ b/crate/src/native.rs
@@ -1,11 +1,13 @@
 //! Native-only functions.
 //! Includes functions that open images from the file-system, etc.,
 
-extern crate image;
-extern crate rand;
+use image;
+use rand;
 use image::DynamicImage::ImageRgba8;
 use image::{GenericImageView, ImageBuffer, ImageError};
 use std::io;
+use std::io;
+use std::fs::File;
 // use wasm_bindgen::prelude::*;
 use crate::PhotonImage;
 use thiserror::Error;
@@ -51,6 +53,34 @@ pub fn open_image(img_path: &str) -> Result<PhotonImage, OpenError> {
     })
 }
 
+/// Saves a image from a byte slice
+/// A PhotonImage is returned.
+/// # Arguments
+/// * `buffer` - A byte slice containing the image you want to edit.
+///
+/// # Example
+/// ```no_run
+/// use photon_rs::native::open_image_from_bytes;
+///
+/// // Code to read a file to buffer. If you are reading from a file its better to use `open_image`
+/// let buffer = std::fs::read("file.png")?.as_slice();
+///
+/// // Open the image. A PhotonImage is returned.
+/// let img = open_image_from_bytes(buffer).expect("File should open");
+///
+/// // ... image editing functionality here ...
+/// ```
+pub fn open_image_from_bytes(buffer: &[u8]) -> Result<PhotonImage, OpenError> {
+    let img = image::load_from_memory(buffer)?;
+    let (width, height) = img.dimensions();
+    let raw_pixels = img.to_rgba8().to_vec();
+
+    Ok(PhotonImage {
+        raw_pixels,
+        width,
+        height,
+    })
+}
 /// Save the image to the filesystem at a given path.
 /// # Arguments
 /// * img: The PhotonImage you wish to save.
@@ -58,10 +88,11 @@ pub fn open_image(img_path: &str) -> Result<PhotonImage, OpenError> {
 ///
 /// # Example
 /// ```no_run
-/// use photon_rs::native::{open_image};
+/// use photon_rs::native::{open_image, save_image};
 ///
 /// let img = open_image("img.jpg").expect("File should open");
 /// // Save the image at the given path.
+/// save_image(img,"manipulated_image.jpg");
 /// ```
 pub fn save_image(img: PhotonImage, img_path: &str) {
     let raw_pixels = img.raw_pixels;
@@ -72,4 +103,27 @@ pub fn save_image(img: PhotonImage, img_path: &str) {
     let dynimage = ImageRgba8(img_buffer);
 
     dynimage.save(img_path).unwrap();
+}
+
+/// Save the image to a byte slice
+/// # Arguments
+/// * img: The PhotonImage you wish to save.
+///
+/// # Example
+/// ```no_run
+/// use photon_rs::native::{open_image,save_image_to_bytes};
+///
+/// let img = open_image("img.jpg").expect("File should open");
+/// // Save the image at a byteslice
+/// let byt = save_image_to_bytes(img);
+/// ```
+pub fn save_image_to_bytes(img: PhotonImage) -> &[u8] {
+    let raw_pixels = img.raw_pixels;
+    let raw_pixels = img.raw_pixels;
+    let width = img.width;
+    let height = img.height;
+
+    let img_buffer = ImageBuffer::from_vec(width, height, raw_pixels).unwrap();
+    let dynimage = ImageRgba8(img_buffer);
+    dynimage.as_bytes()
 }

--- a/crate/src/native.rs
+++ b/crate/src/native.rs
@@ -59,10 +59,10 @@ pub fn open_image(img_path: &str) -> Result<PhotonImage, OpenError> {
 /// use photon_rs::native::open_image_from_bytes;
 ///
 /// // Code to read a file to buffer. If you are reading from a file its better to use `open_image`
-/// let buffer = std::fs::read("img.jpg").expect("File Should Open").as_slice();
+/// let buffer = std::fs::read("img.jpg").expect("File Should Open");
 ///
 /// // Open the image. A PhotonImage is returned.
-/// let img = open_image_from_bytes(buffer).expect("File should open");
+/// let img = open_image_from_bytes(buffer.as_slice()).expect("File should open");
 ///
 /// // ... image editing functionality here ...
 /// ```

--- a/crate/src/native.rs
+++ b/crate/src/native.rs
@@ -1,7 +1,6 @@
 //! Native-only functions.
 //! Includes functions that open images from the file-system, etc.,
 
-use image;
 use image::DynamicImage::ImageRgba8;
 use image::{GenericImageView, ImageBuffer, ImageError};
 use std::io;
@@ -115,7 +114,6 @@ pub fn save_image(img: PhotonImage, img_path: &str) {
 /// let byt = save_image_to_bytes(img);
 /// ```
 pub fn image_to_bytes(img: PhotonImage) -> Vec<u8> {
-    let raw_pixels = img.raw_pixels;
     let raw_pixels = img.raw_pixels;
     let width = img.width;
     let height = img.height;

--- a/crate/src/native.rs
+++ b/crate/src/native.rs
@@ -2,12 +2,9 @@
 //! Includes functions that open images from the file-system, etc.,
 
 use image;
-use rand;
 use image::DynamicImage::ImageRgba8;
 use image::{GenericImageView, ImageBuffer, ImageError};
-use std::io;
-use std::io;
-use std::fs::File;
+
 // use wasm_bindgen::prelude::*;
 use crate::PhotonImage;
 use thiserror::Error;
@@ -105,19 +102,19 @@ pub fn save_image(img: PhotonImage, img_path: &str) {
     dynimage.save(img_path).unwrap();
 }
 
-/// Save the image to a byte slice
+/// Save the image to a vector of bytes
 /// # Arguments
 /// * img: The PhotonImage you wish to save.
 ///
 /// # Example
 /// ```no_run
-/// use photon_rs::native::{open_image,save_image_to_bytes};
+/// use photon_rs::native::{open_image,image_to_bytes};
 ///
 /// let img = open_image("img.jpg").expect("File should open");
-/// // Save the image at a byteslice
+/// // Save the image at a vec<u8>
 /// let byt = save_image_to_bytes(img);
 /// ```
-pub fn save_image_to_bytes(img: PhotonImage) -> &[u8] {
+pub fn image_to_bytes(img: PhotonImage) -> Vec<u8> {
     let raw_pixels = img.raw_pixels;
     let raw_pixels = img.raw_pixels;
     let width = img.width;
@@ -125,5 +122,5 @@ pub fn save_image_to_bytes(img: PhotonImage) -> &[u8] {
 
     let img_buffer = ImageBuffer::from_vec(width, height, raw_pixels).unwrap();
     let dynimage = ImageRgba8(img_buffer);
-    dynimage.as_bytes()
+    dynimage.to_bytes()
 }

--- a/crate/src/noise.rs
+++ b/crate/src/noise.rs
@@ -1,9 +1,7 @@
 //! Add noise to images.
 
-use image;
 use image::Pixel;
 use image::{GenericImage, GenericImageView};
-use rand;
 use rand::Rng;
 // use wasm_bindgen::prelude::*;
 use crate::helpers;

--- a/crate/src/noise.rs
+++ b/crate/src/noise.rs
@@ -1,9 +1,9 @@
 //! Add noise to images.
 
 use image;
-use rand;
 use image::Pixel;
 use image::{GenericImage, GenericImageView};
+use rand;
 use rand::Rng;
 // use wasm_bindgen::prelude::*;
 use crate::helpers;

--- a/crate/src/noise.rs
+++ b/crate/src/noise.rs
@@ -1,7 +1,7 @@
 //! Add noise to images.
 
-extern crate image;
-extern crate rand;
+use image;
+use rand;
 use image::Pixel;
 use image::{GenericImage, GenericImageView};
 use rand::Rng;

--- a/crate/src/text.rs
+++ b/crate/src/text.rs
@@ -2,12 +2,9 @@
 //! For extended graphic design/text-drawing functionality, see [GDL](https://github.com/silvia-odwyer/gdl),
 //! which is a graphic design library, compatible with Photon.
 
-use image;
-use image::{DynamicImage, Rgba};
-use imageproc;
-use rusttype;
 use crate::iter::ImageIterator;
 use crate::{helpers, PhotonImage};
+use image::{DynamicImage, Rgba};
 use imageproc::distance_transform::Norm;
 use imageproc::drawing::draw_text_mut;
 use imageproc::morphology::dilate_mut;

--- a/crate/src/text.rs
+++ b/crate/src/text.rs
@@ -2,10 +2,10 @@
 //! For extended graphic design/text-drawing functionality, see [GDL](https://github.com/silvia-odwyer/gdl),
 //! which is a graphic design library, compatible with Photon.
 
-extern crate image;
+use image;
 use image::{DynamicImage, Rgba};
-extern crate imageproc;
-extern crate rusttype;
+use imageproc;
+use rusttype;
 use crate::iter::ImageIterator;
 use crate::{helpers, PhotonImage};
 use imageproc::distance_transform::Norm;

--- a/crate/src/transform.rs
+++ b/crate/src/transform.rs
@@ -1,8 +1,8 @@
 //! Image transformations, ie: scale, crop, resize, etc.,
 
-extern crate image;
+use image;
 use image::{GenericImageView, ImageBuffer};
-extern crate wasm_bindgen;
+use wasm_bindgen;
 use crate::helpers;
 use crate::iter::ImageIterator;
 use crate::PhotonImage;

--- a/crate/src/transform.rs
+++ b/crate/src/transform.rs
@@ -1,14 +1,14 @@
 //! Image transformations, ie: scale, crop, resize, etc.,
 
-use image;
-use image::{GenericImageView, ImageBuffer};
-use wasm_bindgen;
 use crate::helpers;
 use crate::iter::ImageIterator;
 use crate::PhotonImage;
+use image;
 use image::imageops::FilterType;
 use image::DynamicImage::ImageRgba8;
 use image::RgbaImage;
+use image::{GenericImageView, ImageBuffer};
+use wasm_bindgen;
 use wasm_bindgen::prelude::*;
 
 #[cfg(target_arch = "wasm32")]

--- a/crate/src/transform.rs
+++ b/crate/src/transform.rs
@@ -3,12 +3,10 @@
 use crate::helpers;
 use crate::iter::ImageIterator;
 use crate::PhotonImage;
-use image;
 use image::imageops::FilterType;
 use image::DynamicImage::ImageRgba8;
 use image::RgbaImage;
 use image::{GenericImageView, ImageBuffer};
-use wasm_bindgen;
 use wasm_bindgen::prelude::*;
 
 #[cfg(target_arch = "wasm32")]


### PR DESCRIPTION
This PR adds two new native methods to aid with Image Serialization and De serialization.

`open_image_from_bytes`

`save_image_to_bytes`

I have added appropriate Doc fixes for the same. 

Note:

I also removed references to `extern crate` as 2018 edition of Rust advises against their use.
https://doc.rust-lang.org/edition-guide/rust-2018/module-system/path-clarity.html