### PR TITLE
Added a new effect: "Frosted Glass"

### DIFF
--- a/crate/Cargo.toml
+++ b/crate/Cargo.toml
@@ -31,6 +31,7 @@ serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0"
 js-sys = "0.3.45"
 node-sys = "0.4.2"
+perlin2d = "0.2.6"
 
 # The `console_error_panic_hook` crate provides better debugging of panics by
 # logging them with `console.error`. This is great for development, but requires

--- a/crate/src/effects.rs
+++ b/crate/src/effects.rs
@@ -852,17 +852,16 @@ pub fn oil(mut photon_image: &mut PhotonImage, radius: i32, intensity: f64) {
 /// // For example, to turn an image of type `PhotonImage` into frosted glass see through:
 /// use photon_rs::effects::frosted_glass;
 /// use photon_rs::native::open_image;
-/// use photon_rs::PhotonImage;
 ///
-/// let img = open_image("img.jpg").expect("File should open");
-/// let frosted_img: PhotonImage = frosted_glass(&img);
+/// let mut img = open_image("img.jpg").expect("File should open");
+/// frosted_glass(&mut img);
 /// ```
 ///
 #[wasm_bindgen]
-pub fn frosted_glass(img: &PhotonImage) -> PhotonImage {
-    let img_orig_buf = img.get_raw_pixels();
-    let width = img.get_width();
-    let height = img.get_height();
+pub fn frosted_glass(photon_image: &mut PhotonImage) {
+    let img_orig_buf = photon_image.get_raw_pixels();
+    let width = photon_image.get_width();
+    let height = photon_image.get_height();
     let end = img_orig_buf.len();
 
     let mut img_buf = Vec::<u8>::new();
@@ -894,7 +893,7 @@ pub fn frosted_glass(img: &PhotonImage) -> PhotonImage {
         img_buf[pixel as usize + 3] = img_orig_buf[pixel_new as usize + 3];
     }
 
-    PhotonImage::new(img_buf, width, height)
+    photon_image.raw_pixels = img_buf;
 }
 // pub fn create_gradient_map(color_a : Rgb, color_b: Rgb) -> Vec<Rgb> {
 //     println!("hi");

--- a/crate/src/effects.rs
+++ b/crate/src/effects.rs
@@ -8,6 +8,7 @@ use image::Rgba;
 use image::{GenericImage, GenericImageView};
 use imageproc::drawing::draw_filled_rect_mut;
 use imageproc::rect::Rect;
+use perlin2d::PerlinNoise2D;
 use std::collections::HashMap;
 use std::f64;
 use wasm_bindgen::prelude::*;
@@ -840,6 +841,60 @@ pub fn oil(mut photon_image: &mut PhotonImage, radius: i32, intensity: f64) {
     }
     let raw_pixels = target.to_bytes();
     photon_image.raw_pixels = raw_pixels;
+}
+/// Turn an image into an frosted glass see through
+///
+/// # Arguments
+/// * `img` - A PhotonImage that contains a view into the image.
+/// # Example
+///
+/// ```no_run
+/// // For example, to turn an image of type `PhotonImage` into frosted glass see through:
+/// use photon_rs::effects::frosted_glass;
+/// use photon_rs::native::open_image;
+/// use photon_rs::PhotonImage;
+///
+/// let img = open_image("img.jpg").expect("File should open");
+/// let frosted_img: PhotonImage = frosted_glass(&img);
+/// ```
+///
+#[wasm_bindgen]
+pub fn frosted_glass(img: &PhotonImage) -> PhotonImage {
+    let img_orig_buf = img.get_raw_pixels();
+    let width = img.get_width();
+    let height = img.get_height();
+    let end = img_orig_buf.len();
+
+    let mut img_buf = Vec::<u8>::new();
+    Vec::resize(&mut img_buf, end, 0_u8);
+
+    let perlin = PerlinNoise2D::new(2, 10.0, 10.0, 10.0, 1.0, (100.0, 100.0), 0.5, 101);
+
+    for pixel in (0..end).step_by(4) {
+        let x = (pixel / 4) / width as usize;
+        let y = (pixel / 4) % width as usize;
+
+        let res = [
+            perlin.get_noise(x as f64, y as f64) - 0.5,
+            (perlin.get_noise(100.0 + x as f64, y as f64) - 0.5) * 4.0,
+        ];
+
+        let x_new = f64::clamp(f64::floor(x as f64 + res[0]), 0.0, height as f64 - 1.0);
+        let x_new = x_new as usize;
+        let y_new = f64::clamp(f64::floor(y as f64 + res[1]), 0.0, width as f64 - 1.0);
+        let y_new = y_new as usize;
+
+        let pixel_new = (x_new * width as usize + y_new) * 4;
+        if pixel_new > end as usize {
+            continue;
+        }
+        img_buf[pixel as usize] = img_orig_buf[pixel_new as usize];
+        img_buf[pixel as usize + 1] = img_orig_buf[pixel_new as usize + 1];
+        img_buf[pixel as usize + 2] = img_orig_buf[pixel_new as usize + 2];
+        img_buf[pixel as usize + 3] = img_orig_buf[pixel_new as usize + 3];
+    }
+
+    PhotonImage::new(img_buf, width, height)
 }
 // pub fn create_gradient_map(color_a : Rgb, color_b: Rgb) -> Vec<Rgb> {
 //     println!("hi");


### PR DESCRIPTION
# Frosted Glass

I have created a crate for generating [Perlin noise in 2D](https://crates.io/crates/perlin2d), using which I have created the `frosted glass` effect.

## Example Usage:
```rust
use photon_rs::native::{open_image, save_image};
use photon_rs::PhotonImage;
use photon_rs::effects::frosted_glass;

let mut img = open_image("image.jpg").expect("File not found");
frosted_glass(&mut img);

save_image(img, "image_frosted.jpg");
```
## Example Outputs:
| OriginaI image| Frosted Glass Image|
|------------------|----------------------------|
|![image0](https://user-images.githubusercontent.com/30759667/115706395-392d8c00-a38b-11eb-9cde-54bb8f3af1c9.jpg)|![image0_result](https://user-images.githubusercontent.com/30759667/115706434-4480b780-a38b-11eb-8329-591c16c45952.jpg)|
|![image2](https://user-images.githubusercontent.com/30759667/115706515-5f532c00-a38b-11eb-9276-4b22ee3e267f.jpg)|![image2_result](https://user-images.githubusercontent.com/30759667/115706548-67ab6700-a38b-11eb-8a73-35d87ae22578.jpg)|
|![image1](https://user-images.githubusercontent.com/30759667/115706628-7eea5480-a38b-11eb-8c3a-3cab2b67e0b8.jpg)|![image1_result](https://user-images.githubusercontent.com/30759667/115706658-8578cc00-a38b-11eb-86de-1c9daba13513.jpg)|
|![image3](https://user-images.githubusercontent.com/30759667/115706753-9d505000-a38b-11eb-89e2-707272d4dc6d.jpg)|![image3_result](https://user-images.githubusercontent.com/30759667/115706852-b5c06a80-a38b-11eb-936b-55ffcd5d8bac.jpg)|




