### PR TITLE
Disable default features for imageproc dependency

### DIFF
--- a/crate/Cargo.toml
+++ b/crate/Cargo.toml
@@ -22,7 +22,7 @@ image = "0.23.12"
 palette="0.5.0"
 rand="0.7.2"
 num="0.3.1"
-imageproc="0.22.0"
+imageproc = { version = "0.22.0", default-features = false }
 rusttype="0.9.2"
 base64="0.13.0"
 time="0.2.23"


### PR DESCRIPTION
Imageproc enables rayon as default feature.
Rayon works not well on wasm.
Getting error:
```
panicked at 'The global thread pool has not been initialized.: ThreadPoolBuildError { kind: IOError(Custom { kind: Other, error: "operation not supported on this platform" }) }',
```
This always happens for me, when I add photon-rs to my project and
read a jpeg image using 
```
image::load_from_memory(&data).unwrap();
```
where data is jpeg file data.