### PR TITLE
Unecessary mut

### DIFF
--- a/crate/src/effects.rs
+++ b/crate/src/effects.rs
@@ -736,7 +736,7 @@ pub fn horizontal_strips(mut photon_image: &mut PhotonImage, num_strips: u8) {
 /// use photon_rs::native::open_image;
 /// use photon_rs::Rgb;
 ///
-/// color = Rgb::new(255u8, 0u8, 0u8);
+/// let color = Rgb::new(255u8, 0u8, 0u8);
 /// let mut img = open_image("img.jpg").expect("File should open");
 /// color_horizontal_strips(&mut img, 8u8, color);
 /// ```
@@ -810,7 +810,7 @@ pub fn vertical_strips(mut photon_image: &mut PhotonImage, num_strips: u8) {
 /// use photon_rs::native::open_image;
 /// use photon_rs::Rgb;
 ///
-/// color = Rgb::new(255u8, 0u8, 0u8);
+/// let color = Rgb::new(255u8, 0u8, 0u8);
 /// let mut img = open_image("img.jpg").expect("File should open");
 /// color_vertical_strips(&mut img, 8u8, color);
 /// ```

--- a/crate/src/effects.rs
+++ b/crate/src/effects.rs
@@ -734,7 +734,7 @@ pub fn horizontal_strips(mut photon_image: &mut PhotonImage, num_strips: u8) {
 /// // For example, to oil an image of type `PhotonImage`:
 /// use photon_rs::effects::color_horizontal_strips;
 /// use photon_rs::native::open_image;
-/// user photon_rs::Rgb;
+/// use photon_rs::Rgb;
 ///
 /// color = Rgb::new(255u8, 0u8, 0u8);
 /// let mut img = open_image("img.jpg").expect("File should open");
@@ -808,7 +808,7 @@ pub fn vertical_strips(mut photon_image: &mut PhotonImage, num_strips: u8) {
 /// // For example, to oil an image of type `PhotonImage`:
 /// use photon_rs::effects::color_vertical_strips;
 /// use photon_rs::native::open_image;
-/// user photon_rs::Rgb;
+/// use photon_rs::Rgb;
 ///
 /// color = Rgb::new(255u8, 0u8, 0u8);
 /// let mut img = open_image("img.jpg").expect("File should open");


### PR DESCRIPTION
Some variables are necessarily borrowed as mutable. I was working on something when this came up as an ide suggestion.