### PR TITLE
HOTFIX: fix clamped mut

### DIFF
--- a/crate/src/lib.rs
+++ b/crate/src/lib.rs
@@ -144,7 +144,7 @@ impl PhotonImage {
     #[allow(clippy::unnecessary_mut_passed)]
     pub fn get_image_data(&mut self) -> ImageData {
         ImageData::new_with_u8_clamped_array_and_sh(
-            Clamped(&self.raw_pixels),
+            Clamped(&mut self.raw_pixels),
             self.width,
             self.height,
         )
@@ -350,8 +350,9 @@ pub fn putImageData(
     new_image: PhotonImage,
 ) {
     // Convert the raw pixels back to an ImageData object.
+    let mut raw_pixels = new_image.raw_pixels;
     let new_img_data = ImageData::new_with_u8_clamped_array_and_sh(
-        Clamped(&new_image.raw_pixels),
+        Clamped(&mut raw_pixels),
         canvas.width(),
         canvas.height(),
     );
@@ -414,10 +415,10 @@ pub fn base64_to_vec(base64: &str) -> Vec<u8> {
 #[wasm_bindgen]
 #[allow(clippy::unnecessary_mut_passed)]
 pub fn to_image_data(photon_image: PhotonImage) -> ImageData {
-    let raw_pixels = photon_image.raw_pixels;
+    let mut raw_pixels = photon_image.raw_pixels;
     let width = photon_image.width;
     let height = photon_image.height;
-    ImageData::new_with_u8_clamped_array_and_sh(Clamped(&raw_pixels), width, height)
+    ImageData::new_with_u8_clamped_array_and_sh(Clamped(&mut raw_pixels), width, height)
         .unwrap()
 }
 


### PR DESCRIPTION
@silvia-odwyer  hotfix
```
   Compiling photon-rs v0.3.1 (/home/horky/Documents/WorkspaceRust/forks/photon/crate)
error[E0308]: mismatched types
   --> crate/src/lib.rs:147:21
    |
147 |             Clamped(&self.raw_pixels),
    |                     ^^^^^^^^^^^^^^^^ types differ in mutability
    |
    = note: expected mutable reference `&mut [u8]`
                       found reference `&Vec<u8>`

error[E0308]: mismatched types
   --> crate/src/lib.rs:354:17
    |
354 |         Clamped(&new_image.raw_pixels),
    |                 ^^^^^^^^^^^^^^^^^^^^^ types differ in mutability
    |
    = note: expected mutable reference `&mut [u8]`
                       found reference `&Vec<u8>`

error[E0308]: mismatched types
   --> crate/src/lib.rs:420:57
    |
420 |     ImageData::new_with_u8_clamped_array_and_sh(Clamped(&raw_pixels), width, height)
    |                                                         ^^^^^^^^^^^ types differ in mutability
    |
    = note: expected mutable reference `&mut [u8]`
                       found reference `&Vec<u8>`

error: aborting due to 3 previous errors

For more information about this error, try `rustc --explain E0308`.
error: could not compile `photon-rs`

To learn more, run the command again with --verbose.

```