### PR TITLE
Merge open and save errors into a single error type

### DIFF
--- a/crate/examples/example.rs
+++ b/crate/examples/example.rs
@@ -21,7 +21,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         photon::colour_spaces::hsl(&mut img, effect, 0.2_f32);
 
         // Write the contents of this image in JPG format.
-        photon::native::save_image(img, &format!("output_{}.jpg", effect)[..]);
+        photon::native::save_image(img, &format!("output_{}.jpg", effect)[..])?;
 
         let end = Instant::now();
         println!(

--- a/crate/examples/seam_carver.rs
+++ b/crate/examples/seam_carver.rs
@@ -18,7 +18,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("after = w: {}, h: {}", w, h);
 
     // Write the contents of this image in JPEG format.
-    photon_rs::native::save_image(res, "output_seam_carver.jpg");
+    photon_rs::native::save_image(res, "output_seam_carver.jpg")?;
     let end = time::Instant::now();
     println!(
         "Took {} seconds to seam carve image.",

--- a/crate/src/bin/bin.rs
+++ b/crate/src/bin/bin.rs
@@ -16,7 +16,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let output_img_path = "output.jpg";
 
     // Write file to filesystem.
-    save_image(img, output_img_path);
+    save_image(img, output_img_path)?;
     let end = Instant::now();
     println!(
         "Took {} seconds to increment red channel by 40 on image.",


### PR DESCRIPTION
This PR;

1. Merges `native::OpenError` and `native:SaveError` into `native::Error`.
2. Modifies `save_image` to be a panic-free function (with an exception, see 3rd point).
3. Removes `BufferSize` error. Because previously implemented `native::SaveError::BufferSize` error does not make sense. It was related to incorrect argument passing for `ImageBuffer::from_vec` function. This should raise a panic and shouldn't be related to the user input.
4. Updates relevant call sites.

See: #28