### PR TITLE
Use built-in clamp function and remove num dependency

### DIFF
--- a/crate/Cargo.toml
+++ b/crate/Cargo.toml
@@ -21,7 +21,6 @@ crate-type = ["cdylib", "rlib"]
 image = { version = "0.23.12", default-features = false, features = ["gif", "jpeg", "ico", "png", "pnm", "tga", "tiff", "webp", "bmp", "hdr", "dxt", "dds", "farbfeld"] }
 palette="0.5.0"
 rand="0.7.2"
-num="0.3.1"
 imageproc = { version = "0.22.0", default-features = false }
 rusttype="0.9.2"
 base64="0.13.0"

--- a/crate/src/channels.rs
+++ b/crate/src/channels.rs
@@ -54,7 +54,7 @@ pub fn alter_channel(img: &mut PhotonImage, channel: usize, amt: i16) {
 
     for i in (channel..end).step_by(4) {
         let inc_val: i16 = img.raw_pixels[i] as i16 + amt as i16;
-        img.raw_pixels[i] = num::clamp(inc_val, 0, 255) as u8;
+        img.raw_pixels[i] = inc_val.clamp(0, 255) as u8;
     }
 }
 
@@ -166,8 +166,8 @@ pub fn alter_two_channels(
         let inc_val1: i16 = img.raw_pixels[i + channel1] as i16 + amt1 as i16;
         let inc_val2: i16 = img.raw_pixels[i + channel2] as i16 + amt2 as i16;
 
-        img.raw_pixels[i + channel1] = num::clamp(inc_val1, 0, 255) as u8;
-        img.raw_pixels[i + channel2] = num::clamp(inc_val2, 0, 255) as u8;
+        img.raw_pixels[i + channel1] = inc_val1.clamp(0, 255) as u8;
+        img.raw_pixels[i + channel2] = inc_val2.clamp(0, 255) as u8;
     }
 }
 
@@ -208,9 +208,9 @@ pub fn alter_channels(img: &mut PhotonImage, r_amt: i16, g_amt: i16, b_amt: i16)
         let g_val: i16 = img.raw_pixels[i + 1] as i16 + g_amt as i16;
         let b_val: i16 = img.raw_pixels[i + 2] as i16 + b_amt as i16;
 
-        img.raw_pixels[i] = num::clamp(r_val, 0, 255) as u8;
-        img.raw_pixels[i + 1] = num::clamp(g_val, 0, 255) as u8;
-        img.raw_pixels[i + 2] = num::clamp(b_val, 0, 255) as u8;
+        img.raw_pixels[i] = r_val.clamp(0, 255) as u8;
+        img.raw_pixels[i + 1] = g_val.clamp(0, 255) as u8;
+        img.raw_pixels[i + 2] = b_val.clamp(0, 255) as u8;
     }
 }
 

--- a/crate/src/conv.rs
+++ b/crate/src/conv.rs
@@ -253,9 +253,9 @@ fn box_blur_horizontal(
             val_b += src[ri + 2] as i32 - fv_b;
             ri += 4;
 
-            target[ti] = num::clamp(val_r as f32 * iarr, 0.0, 255.0) as u8;
-            target[ti + 1] = num::clamp(val_g as f32 * iarr, 0.0, 255.0) as u8;
-            target[ti + 2] = num::clamp(val_b as f32 * iarr, 0.0, 255.0) as u8;
+            target[ti] = (val_r as f32 * iarr).clamp(0.0, 255.0) as u8;
+            target[ti + 1] = (val_g as f32 * iarr).clamp(0.0, 255.0) as u8;
+            target[ti + 2] = (val_b as f32 * iarr).clamp(0.0, 255.0) as u8;
             ti += 4;
         }
 
@@ -266,9 +266,9 @@ fn box_blur_horizontal(
             ri += 4;
             li += 4;
 
-            target[ti] = num::clamp(val_r as f32 * iarr, 0.0, 255.0) as u8;
-            target[ti + 1] = num::clamp(val_g as f32 * iarr, 0.0, 255.0) as u8;
-            target[ti + 2] = num::clamp(val_b as f32 * iarr, 0.0, 255.0) as u8;
+            target[ti] = (val_r as f32 * iarr).clamp(0.0, 255.0) as u8;
+            target[ti + 1] = (val_g as f32 * iarr).clamp(0.0, 255.0) as u8;
+            target[ti + 2] = (val_b as f32 * iarr).clamp(0.0, 255.0) as u8;
             ti += 4;
         }
 
@@ -278,9 +278,9 @@ fn box_blur_horizontal(
             val_b += lv_b as i32 - src[li + 2] as i32;
             li += 4;
 
-            target[ti] = num::clamp(val_r as f32 * iarr, 0.0, 255.0) as u8;
-            target[ti + 1] = num::clamp(val_g as f32 * iarr, 0.0, 255.0) as u8;
-            target[ti + 2] = num::clamp(val_b as f32 * iarr, 0.0, 255.0) as u8;
+            target[ti] = (val_r as f32 * iarr).clamp(0.0, 255.0) as u8;
+            target[ti + 1] = (val_g as f32 * iarr).clamp(0.0, 255.0) as u8;
+            target[ti + 2] = (val_b as f32 * iarr).clamp(0.0, 255.0) as u8;
             ti += 4;
         }
     }
@@ -324,9 +324,9 @@ fn box_blur_vertical(
             val_b += src[ri + 2] as i32 - fv_b;
             ri += width as usize * 4;
 
-            target[ti] = num::clamp(val_r as f32 * iarr, 0.0, 255.0) as u8;
-            target[ti + 1] = num::clamp(val_g as f32 * iarr, 0.0, 255.0) as u8;
-            target[ti + 2] = num::clamp(val_b as f32 * iarr, 0.0, 255.0) as u8;
+            target[ti] = (val_r as f32 * iarr).clamp(0.0, 255.0) as u8;
+            target[ti + 1] = (val_g as f32 * iarr).clamp(0.0, 255.0) as u8;
+            target[ti + 2] = (val_b as f32 * iarr).clamp(0.0, 255.0) as u8;
             ti += width as usize * 4;
         }
 
@@ -337,9 +337,9 @@ fn box_blur_vertical(
             ri += width as usize * 4;
             li += width as usize * 4;
 
-            target[ti] = num::clamp(val_r as f32 * iarr, 0.0, 255.0) as u8;
-            target[ti + 1] = num::clamp(val_g as f32 * iarr, 0.0, 255.0) as u8;
-            target[ti + 2] = num::clamp(val_b as f32 * iarr, 0.0, 255.0) as u8;
+            target[ti] = (val_r as f32 * iarr).clamp(0.0, 255.0) as u8;
+            target[ti + 1] = (val_g as f32 * iarr).clamp(0.0, 255.0) as u8;
+            target[ti + 2] = (val_b as f32 * iarr).clamp(0.0, 255.0) as u8;
             ti += width as usize * 4;
         }
 
@@ -349,9 +349,9 @@ fn box_blur_vertical(
             val_b += lv_b as i32 - src[li + 2] as i32;
             li += width as usize * 4;
 
-            target[ti] = num::clamp(val_r as f32 * iarr, 0.0, 255.0) as u8;
-            target[ti + 1] = num::clamp(val_g as f32 * iarr, 0.0, 255.0) as u8;
-            target[ti + 2] = num::clamp(val_b as f32 * iarr, 0.0, 255.0) as u8;
+            target[ti] = (val_r as f32 * iarr).clamp(0.0, 255.0) as u8;
+            target[ti + 1] = (val_g as f32 * iarr).clamp(0.0, 255.0) as u8;
+            target[ti + 2] = (val_b as f32 * iarr).clamp(0.0, 255.0) as u8;
             ti += width as usize * 4;
         }
     }

--- a/crate/src/effects.rs
+++ b/crate/src/effects.rs
@@ -584,7 +584,7 @@ pub fn inc_brightness(photon_image: &mut PhotonImage, brightness: u8) {
 pub fn adjust_contrast(mut photon_image: &mut PhotonImage, contrast: f32) {
     let mut img = helpers::dyn_image_from_raw(photon_image);
 
-    let clamped_contrast = num::clamp(contrast, -255.0, 255.0);
+    let clamped_contrast = contrast.clamp(-255.0, 255.0);
 
     // Some references:
     // https://math.stackexchange.com/questions/906240/algorithms-to-increase-or-decrease-the-contrast-of-an-image
@@ -596,7 +596,7 @@ pub fn adjust_contrast(mut photon_image: &mut PhotonImage, contrast: f32) {
 
     for (i, table) in lookup_table.iter_mut().enumerate().take(256_usize) {
         let new_val = i as f32 * factor + offset;
-        *table = num::clamp(new_val, 0.0, 255.0) as u8;
+        *table = new_val.clamp(0.0, 255.0) as u8;
     }
 
     for (x, y) in ImageIterator::with_dimension(&img.dimensions()) {


### PR DESCRIPTION
This PR replaces `num::clamp` function with built-in `clamp` function. As a result, we no longer need the `num` dependency at all. So this PR removes it as well (although it's still used by the dependencies that we included). The changes have a very minor effect on WASM package size (52 bytes reduction) while increasing the build time which can be considered negligible due to precision (0.253 seconds increase).

| | Before | This PR | Difference |
|-|-|-|-|
| Build Time | 1m 3.796s | 1m 4.049s | +0.253 seconds |
| WASM Size | 3,991,311 bytes | 3,991,259 bytes | -52 bytes |