### PR TITLE
Resolve panic in Gaussian blur

### DIFF
--- a/crate/src/conv.rs
+++ b/crate/src/conv.rs
@@ -3,6 +3,7 @@
 use crate::helpers;
 use crate::PhotonImage;
 use image::DynamicImage::ImageRgba8;
+use std::cmp::min;
 use wasm_bindgen::prelude::*;
 
 type Kernel = [f32; 9];
@@ -159,6 +160,17 @@ pub fn gaussian_blur(photon_image: &mut PhotonImage, radius: i32) {
     let width = photon_image.get_width();
     let height = photon_image.get_height();
     let mut target: Vec<u8> = src.clone();
+
+    // Clamp radius value when it exceeds width or height.
+    // Divide by 2 since maximal radius must satisfy these conditions:
+    // rad + ((w - 1) * h) + rad < w * h
+    // rad + ((h - 1) * w) + rad < w * h
+    // After all transformations they become:
+    // rad < h / 2
+    // rad < w / 2
+    // Subtract 1 because the inequalies are strict.
+    let radius = min(width as i32 / 2 - 1, radius);
+    let radius = min(height as i32 / 2 - 1, radius);
 
     let bxs = boxes_for_gauss(radius as f32, 3);
     box_blur_inner(&mut src, &mut target, width, height, (bxs[0] - 1) / 2);


### PR DESCRIPTION
Override radius value in order to avoid exceeding image bounds.

Resolves https://github.com/silvia-odwyer/photon/issues/59.