### PR TITLE
chore: fix to_bytes and add jpeg_saving support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,18 +64,3 @@ jobs:
         with:
           command: clippy
           args: --all-features -- -D warnings
-  wasm32:
-    name: Wasm32 check
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          target: wasm32-unknown-unknown
-          toolchain: stable
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --all-features --benches --bins --examples --tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,3 +64,18 @@ jobs:
         with:
           command: clippy
           args: --all-features -- -D warnings
+  wasm32:
+    name: Wasm32 check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          target: wasm32-unknown-unknown
+          toolchain: stable
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --all-features --benches --bins --examples --tests

--- a/.github/workflows/compile_wasm.yaml
+++ b/.github/workflows/compile_wasm.yaml
@@ -1,4 +1,4 @@
-on: [push, pull_request]
+on: push
 
 name: Wasm testing and building
 

--- a/.github/workflows/compile_wasm.yaml
+++ b/.github/workflows/compile_wasm.yaml
@@ -21,6 +21,7 @@ jobs:
   build_wasm:
     name: Build Wasm Module
     runs-on: ubuntu-latest
+    needs: wasm32
     steps:
       - uses: actions/checkout@v2
       - name: Install

--- a/.github/workflows/compile_wasm.yaml
+++ b/.github/workflows/compile_wasm.yaml
@@ -27,8 +27,11 @@ jobs:
       - name: Install
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
       - run: wasm-pack build ./crate
+      - run: rm ./crate/pkg/.gitignore
       - name: Deploy
-        uses: JamesIves/github-pages-deploy-action@v4.3.3
-        with:
-          branch: compiled-wasm
-          folder: crate/pkg
+        uses: s0/git-publish-subdir-action@develop
+        env:
+          REPO: self
+          BRANCH: compiled-wasm
+          FOLDER: crate/pkg
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/compile_wasm.yaml
+++ b/.github/workflows/compile_wasm.yaml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
-      - run: wasm-pack build ./crate
+      - run: wasm-pack build --target nodejs --out-name photon-node ./crate
       - run: rm ./crate/pkg/.gitignore
       - name: Deploy
         uses: s0/git-publish-subdir-action@develop

--- a/.github/workflows/compile_wasm.yaml
+++ b/.github/workflows/compile_wasm.yaml
@@ -30,7 +30,5 @@ jobs:
       - name: Deploy
         uses: JamesIves/github-pages-deploy-action@v4.3.3
         env:
-          REPO: self
-          BRANCH: compiled-wasm
-          FOLDER: crate/pkg
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          branch: compiled-wasm
+          folder: crate/pkg

--- a/.github/workflows/compile_wasm.yaml
+++ b/.github/workflows/compile_wasm.yaml
@@ -29,6 +29,6 @@ jobs:
       - run: wasm-pack build ./crate
       - name: Deploy
         uses: JamesIves/github-pages-deploy-action@v4.3.3
-        env:
+        with:
           branch: compiled-wasm
           folder: crate/pkg

--- a/.github/workflows/compile_wasm.yaml
+++ b/.github/workflows/compile_wasm.yaml
@@ -28,7 +28,7 @@ jobs:
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
       - run: wasm-pack build ./crate
       - name: Deploy
-        uses: s0/git-publish-subdir-action@develop
+        uses: JamesIves/github-pages-deploy-action@v4.3.3
         env:
           REPO: self
           BRANCH: compiled-wasm

--- a/.github/workflows/compile_wasm.yaml
+++ b/.github/workflows/compile_wasm.yaml
@@ -1,0 +1,35 @@
+on: [push, pull_request]
+
+name: Wasm testing and building
+
+jobs:
+  wasm32:
+    name: Wasm32 check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          target: wasm32-unknown-unknown
+          toolchain: stable
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --all-features --benches --bins --examples --tests
+  build_wasm:
+    name: Build Wasm Module
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+      - run: wasm-pack build ./crate
+      - name: Deploy
+        uses: s0/git-publish-subdir-action@develop
+        env:
+          REPO: self
+          BRANCH: compiled-wasm
+          FOLDER: crate/pkg
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/crate/src/lib.rs
+++ b/crate/src/lib.rs
@@ -140,11 +140,24 @@ impl PhotonImage {
         res_base64
     }
 
-    /// Convert the PhotonImage to raw bytes.
+    /// Convert the PhotonImage to raw bytes. Returns JPEG.
     pub fn get_bytes(&self) -> Vec<u8> {
         let mut img = helpers::dyn_image_from_raw(self);
         img = ImageRgba8(img.to_rgba8());
-        img.to_bytes()
+        let mut buffer = vec![];
+        img.write_to(&mut buffer, image::ImageOutputFormat::Png)
+            .unwrap();
+        buffer
+    }
+
+    /// Convert the PhotonImage to raw bytes. Returns a JPEG.
+    pub fn get_bytes_jpeg(&self, quality: u8) -> Vec<u8> {
+        let mut img = helpers::dyn_image_from_raw(self);
+        img = ImageRgba8(img.to_rgba8());
+        let mut buffer = vec![];
+        let out_format = image::ImageOutputFormat::Jpeg(quality);
+        img.write_to(&mut buffer, out_format).unwrap();
+        buffer
     }
 
     /// Convert the PhotonImage's raw pixels to JS-compatible ImageData.


### PR DESCRIPTION
- This PR adds saving_jpeg bytes support with quality and also fixes to_bytes as there was an error with the code.
- I've also added a GH action that compiles the WASM code and saves it to a seperate branch to allow dev installs with 

```
npm add https://github.com/silvia-odwyer/photon#compiled-wasm
```

This is great for testing and development.