### PR TITLE
Add selective colorization

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,6 @@ or filters; this library provides a complete suite of functions to do so, as wel
 Photon is always accepting new filters and functions. In that vein if you'd like to contribute to Photon please submit a Pull Request or add new issues for investigation. Our community is our lifeblood, and we appreciate all the support we get from individuals like you.
 
 ## To Do
-- Selective colorization
 - Fade
 - Blend images using browser-specific functions for WASM version of library.
 - Vintage images with light leaks, grains, etc.,


### PR DESCRIPTION
This PR adds selective colorization effect by replacing the commented-out implementation. Please note that the new implementation mixes the colors of matched pixels rather than the reference color compared to the old implementation. Mixing with the reference color produces hard transitions around matched area boundaries whatever `fraction` value is provided. The new implementation helps smooth transitions around matched areas with low `fraction` values.