### PR TITLE
Add `enable_wasm` crate feature

### DIFF
--- a/crate/Cargo.toml
+++ b/crate/Cargo.toml
@@ -25,11 +25,11 @@ imageproc = { version = "0.22.0", default-features = false }
 rusttype="0.9.2"
 base64="0.13.0"
 time="0.2.23"
-wasm-bindgen = "=0.2.78"
+wasm-bindgen = { version = "=0.2.78", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0"
-js-sys = "0.3.45"
-node-sys = "0.4.2"
+js-sys = { version = "0.3.45", optional = true }
+node-sys = { version = "0.4.2", optional = true }
 perlin2d = "0.2.6"
 
 # The `console_error_panic_hook` crate provides better debugging of panics by
@@ -72,4 +72,12 @@ features = [
 ]
 
 [features]
-default = ["console_error_panic_hook"]
+default = ["enable_wasm"]
+enable_wasm = [
+  "wasm-bindgen",
+  "console_error_panic_hook",
+  "js-sys",
+  "node-sys",
+  "wasm-bindgen",
+  "wee_alloc"
+]

--- a/crate/Cargo.toml
+++ b/crate/Cargo.toml
@@ -79,6 +79,5 @@ enable_wasm = [
   "web-sys",
   "js-sys",
   "node-sys",
-  "console_error_panic_hook",
-  "wee_alloc"
+  "console_error_panic_hook"
 ]

--- a/crate/Cargo.toml
+++ b/crate/Cargo.toml
@@ -70,14 +70,15 @@ features = [
   'CssStyleDeclaration',
   'EventTarget',
 ]
+optional = true
 
 [features]
 default = ["enable_wasm"]
 enable_wasm = [
   "wasm-bindgen",
-  "console_error_panic_hook",
+  "web-sys",
   "js-sys",
   "node-sys",
-  "wasm-bindgen",
+  "console_error_panic_hook",
   "wee_alloc"
 ]

--- a/crate/src/channels.rs
+++ b/crate/src/channels.rs
@@ -9,6 +9,8 @@ use crate::iter::ImageIterator;
 use crate::{PhotonImage, Rgb};
 use palette::{FromColor, IntoColor};
 use palette::{Hue, Lab, Lch, Saturate, Shade, Srgb, Srgba};
+
+#[cfg(feature = "enable_wasm")]
 use wasm_bindgen::prelude::*;
 
 /// Alter a select channel by incrementing or decrementing its value by a constant.
@@ -43,7 +45,7 @@ use wasm_bindgen::prelude::*;
 /// alter_channel(&mut img, 1_usize, -20_i16);
 /// ```
 /// **Note**: Note the use of a minus symbol when decreasing the channel.
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn alter_channel(img: &mut PhotonImage, channel: usize, amt: i16) {
     if channel > 2 {
         panic!("Invalid channel index passed. Channel must be 0, 1, or 2 (Red=0, Green=1, Blue=2)");
@@ -75,7 +77,7 @@ pub fn alter_channel(img: &mut PhotonImage, channel: usize, amt: i16) {
 /// let mut img = open_image("img.jpg").expect("File should open");
 /// alter_red_channel(&mut img, 10_i16);
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn alter_red_channel(photon_image: &mut PhotonImage, amt: i16) {
     alter_channel(photon_image, 0, amt)
 }
@@ -96,7 +98,7 @@ pub fn alter_red_channel(photon_image: &mut PhotonImage, amt: i16) {
 /// let mut img = open_image("img.jpg").expect("File should open");
 /// alter_green_channel(&mut img, 20_i16);
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn alter_green_channel(img: &mut PhotonImage, amt: i16) {
     alter_channel(img, 1, amt)
 }
@@ -117,7 +119,7 @@ pub fn alter_green_channel(img: &mut PhotonImage, amt: i16) {
 /// let mut img = open_image("img.jpg").expect("File should open");
 /// alter_blue_channel(&mut img, 10_i16);
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn alter_blue_channel(img: &mut PhotonImage, amt: i16) {
     alter_channel(img, 2, amt)
 }
@@ -141,7 +143,7 @@ pub fn alter_blue_channel(img: &mut PhotonImage, amt: i16) {
 /// let mut img = open_image("img.jpg").expect("File should open");
 /// alter_two_channels(&mut img, 0_usize, 10_i16, 2_usize, 20_i16);
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn alter_two_channels(
     img: &mut PhotonImage,
     channel1: usize,
@@ -191,7 +193,7 @@ pub fn alter_two_channels(
 /// let mut img = open_image("img.jpg").expect("File should open");
 /// alter_channels(&mut img, 10_i16, 20_i16, 50_i16);
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn alter_channels(img: &mut PhotonImage, r_amt: i16, g_amt: i16, b_amt: i16) {
     if r_amt > 255 {
         panic!("Invalid r_amt passed. Amount to inc/dec channel by should be between -255 and 255");
@@ -234,7 +236,7 @@ pub fn alter_channels(img: &mut PhotonImage, r_amt: i16, g_amt: i16, b_amt: i16)
 /// let mut img = open_image("img.jpg").expect("File should open");
 /// remove_channel(&mut img, 0_usize, 100_u8);
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn remove_channel(img: &mut PhotonImage, channel: usize, min_filter: u8) {
     if channel > 2 {
         panic!("Invalid channel index passed. Channel must be equal to 0, 1, or 2.");
@@ -263,7 +265,7 @@ pub fn remove_channel(img: &mut PhotonImage, channel: usize, min_filter: u8) {
 /// let mut img = open_image("img.jpg").expect("File should open");
 /// remove_red_channel(&mut img, 50_u8);
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn remove_red_channel(img: &mut PhotonImage, min_filter: u8) {
     remove_channel(img, 0, min_filter)
 }
@@ -284,7 +286,7 @@ pub fn remove_red_channel(img: &mut PhotonImage, min_filter: u8) {
 /// let mut img = open_image("img.jpg").expect("File should open");
 /// remove_green_channel(&mut img, 50_u8);
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn remove_green_channel(img: &mut PhotonImage, min_filter: u8) {
     remove_channel(img, 1, min_filter)
 }
@@ -305,7 +307,7 @@ pub fn remove_green_channel(img: &mut PhotonImage, min_filter: u8) {
 /// let mut img = open_image("img.jpg").expect("File should open");
 /// remove_blue_channel(&mut img, 50_u8);
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn remove_blue_channel(img: &mut PhotonImage, min_filter: u8) {
     remove_channel(img, 2, min_filter)
 }
@@ -327,7 +329,7 @@ pub fn remove_blue_channel(img: &mut PhotonImage, min_filter: u8) {
 /// let mut img = open_image("img.jpg").expect("File should open");
 /// swap_channels(&mut img, 0_usize, 2_usize);
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn swap_channels(img: &mut PhotonImage, mut channel1: usize, mut channel2: usize) {
     if channel1 > 2 {
         panic!("Invalid channel index passed. Channel1 must be equal to 0, 1, or 2.");
@@ -361,7 +363,7 @@ pub fn swap_channels(img: &mut PhotonImage, mut channel1: usize, mut channel2: u
 /// let mut img = open_image("img.jpg").expect("File should open");
 /// invert(&mut img);
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn invert(photon_image: &mut PhotonImage) {
     let end = photon_image.get_raw_pixels().len();
 
@@ -398,7 +400,7 @@ pub fn invert(photon_image: &mut PhotonImage) {
 /// let mut img = open_image("img.jpg").expect("File should open");
 /// selective_hue_rotate(&mut img, ref_color, 180_f32);
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn selective_hue_rotate(
     mut photon_image: &mut PhotonImage,
     ref_color: Rgb,
@@ -482,7 +484,7 @@ pub fn selective_hue_rotate(
 /// let mut img = open_image("img.jpg").expect("File should open");
 /// selective_color_convert(&mut img, ref_color, new_color, 0.25);
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn selective_color_convert(
     photon_image: &mut PhotonImage,
     ref_color: Rgb,
@@ -579,7 +581,7 @@ pub fn selective_color_convert(
 /// let mut img = open_image("img.jpg").expect("File should open");
 /// selective_lighten(&mut img, ref_color, 0.2_f32);
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn selective_lighten(img: &mut PhotonImage, ref_color: Rgb, amt: f32) {
     selective(img, "lighten", ref_color, amt)
 }
@@ -606,7 +608,7 @@ pub fn selective_lighten(img: &mut PhotonImage, ref_color: Rgb, amt: f32) {
 /// let mut img = open_image("img.jpg").expect("File should open");
 /// selective_desaturate(&mut img, ref_color, 0.1_f32);
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn selective_desaturate(img: &mut PhotonImage, ref_color: Rgb, amt: f32) {
     selective(img, "desaturate", ref_color, amt)
 }
@@ -633,7 +635,7 @@ pub fn selective_desaturate(img: &mut PhotonImage, ref_color: Rgb, amt: f32) {
 /// let mut img = open_image("img.jpg").expect("File should open");
 /// selective_saturate(&mut img, ref_color, 0.1_f32);
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn selective_saturate(img: &mut PhotonImage, ref_color: Rgb, amt: f32) {
     selective(img, "saturate", ref_color, amt);
 }
@@ -726,7 +728,7 @@ fn selective(
 /// let mut img = open_image("img.jpg").expect("File should open");
 /// selective_greyscale(img, ref_color);
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn selective_greyscale(mut photon_image: PhotonImage, ref_color: Rgb) {
     let mut img = helpers::dyn_image_from_raw(&photon_image);
 

--- a/crate/src/colour_spaces.rs
+++ b/crate/src/colour_spaces.rs
@@ -6,6 +6,8 @@ use image::GenericImageView;
 use image::Pixel as ImagePixel;
 use palette::{FromColor, IntoColor};
 use palette::{Hsla, Hsluva, Hsva, Hue, Lcha, Saturate, Shade, Srgba};
+
+#[cfg(feature = "enable_wasm")]
 use wasm_bindgen::prelude::*;
 
 /// Applies gamma correction to an image.
@@ -25,7 +27,7 @@ use wasm_bindgen::prelude::*;
 /// gamma_correction(&mut img, 2.2, 2.2, 2.2);
 /// ```
 ///
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn gamma_correction(
     photon_image: &mut PhotonImage,
     red: f32,
@@ -87,7 +89,7 @@ pub fn gamma_correction(
 /// let mut img = open_image("img.jpg").expect("File should open");
 /// hsluv(&mut img, "saturate", 0.1_f32);
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn hsluv(mut photon_image: &mut PhotonImage, mode: &str, amt: f32) {
     let img = helpers::dyn_image_from_raw(photon_image);
     let (width, height) = img.dimensions();
@@ -155,7 +157,7 @@ pub fn hsluv(mut photon_image: &mut PhotonImage, mode: &str, amt: f32) {
 /// let mut img = open_image("img.jpg").expect("File should open");
 /// lch(&mut img, "saturate", 0.1_f32);
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn lch(mut photon_image: &mut PhotonImage, mode: &str, amt: f32) {
     let img = helpers::dyn_image_from_raw(photon_image);
     let (width, height) = img.dimensions();
@@ -223,7 +225,7 @@ pub fn lch(mut photon_image: &mut PhotonImage, mode: &str, amt: f32) {
 /// let mut img = open_image("img.jpg").expect("File should open");
 /// hsl(&mut img, "saturate", 0.1_f32);
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn hsl(mut photon_image: &mut PhotonImage, mode: &str, amt: f32) {
     // The function logic is kept separate from other colour spaces for now,
     // since other HSL-specific logic may be implemented here, which isn't available in other colour spaces
@@ -292,7 +294,7 @@ pub fn hsl(mut photon_image: &mut PhotonImage, mode: &str, amt: f32) {
 /// let mut img = open_image("img.jpg").expect("File should open");
 /// hsv(&mut img, "saturate", 0.1_f32);
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn hsv(photon_image: &mut PhotonImage, mode: &str, amt: f32) {
     let img = helpers::dyn_image_from_raw(photon_image);
     let (width, height) = img.dimensions();
@@ -354,7 +356,7 @@ pub fn hsv(photon_image: &mut PhotonImage, mode: &str, amt: f32) {
 /// let mut img = open_image("img.jpg").expect("File should open");
 /// hue_rotate_hsl(&mut img, 120_f32);
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn hue_rotate_hsl(img: &mut PhotonImage, degrees: f32) {
     hsl(img, "shift_hue", degrees);
 }
@@ -374,7 +376,7 @@ pub fn hue_rotate_hsl(img: &mut PhotonImage, degrees: f32) {
 /// let mut img = open_image("img.jpg").expect("File should open");
 /// hue_rotate_hsv(&mut img, 120_f32);
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn hue_rotate_hsv(img: &mut PhotonImage, degrees: f32) {
     hsv(img, "shift_hue", degrees);
 }
@@ -394,7 +396,7 @@ pub fn hue_rotate_hsv(img: &mut PhotonImage, degrees: f32) {
 /// let mut img = open_image("img.jpg").expect("File should open");
 /// hue_rotate_lch(&mut img, 120_f32);
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn hue_rotate_lch(img: &mut PhotonImage, degrees: f32) {
     lch(img, "shift_hue", degrees)
 }
@@ -414,7 +416,7 @@ pub fn hue_rotate_lch(img: &mut PhotonImage, degrees: f32) {
 /// let mut img = open_image("img.jpg").expect("File should open");
 /// hue_rotate_hsluv(&mut img, 120_f32);
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn hue_rotate_hsluv(img: &mut PhotonImage, degrees: f32) {
     hsluv(img, "shift_hue", degrees)
 }
@@ -437,7 +439,7 @@ pub fn hue_rotate_hsluv(img: &mut PhotonImage, degrees: f32) {
 /// let mut img = open_image("img.jpg").expect("File should open");
 /// saturate_hsl(&mut img, 0.1_f32);
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn saturate_hsl(img: &mut PhotonImage, level: f32) {
     hsl(img, "saturate", level)
 }
@@ -459,7 +461,7 @@ pub fn saturate_hsl(img: &mut PhotonImage, level: f32) {
 /// let mut img = open_image("img.jpg").expect("File should open");
 /// saturate_lch(&mut img, 0.4_f32);
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn saturate_lch(img: &mut PhotonImage, level: f32) {
     lch(img, "saturate", level)
 }
@@ -481,7 +483,7 @@ pub fn saturate_lch(img: &mut PhotonImage, level: f32) {
 /// let mut img = open_image("img.jpg").expect("File should open");
 /// saturate_hsluv(&mut img, 0.4_f32);
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn saturate_hsluv(img: &mut PhotonImage, level: f32) {
     hsluv(img, "saturate", level)
 }
@@ -503,7 +505,7 @@ pub fn saturate_hsluv(img: &mut PhotonImage, level: f32) {
 /// let mut img = open_image("img.jpg").expect("File should open");
 /// saturate_hsv(&mut img, 0.3_f32);
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn saturate_hsv(img: &mut PhotonImage, level: f32) {
     hsv(img, "saturate", level)
 }
@@ -526,7 +528,7 @@ pub fn saturate_hsv(img: &mut PhotonImage, level: f32) {
 /// let mut img = open_image("img.jpg").expect("File should open");
 /// lighten_lch(&mut img, 0.1_f32);
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn lighten_lch(img: &mut PhotonImage, level: f32) {
     lch(img, "lighten", level)
 }
@@ -549,7 +551,7 @@ pub fn lighten_lch(img: &mut PhotonImage, level: f32) {
 /// let mut img = open_image("img.jpg").expect("File should open");
 /// lighten_hsluv(&mut img, 0.1_f32);
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn lighten_hsluv(img: &mut PhotonImage, level: f32) {
     hsluv(img, "lighten", level)
 }
@@ -571,7 +573,7 @@ pub fn lighten_hsluv(img: &mut PhotonImage, level: f32) {
 /// let mut img = open_image("img.jpg").expect("File should open");
 /// lighten_hsl(&mut img, 0.1_f32);
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn lighten_hsl(img: &mut PhotonImage, level: f32) {
     hsl(img, "lighten", level)
 }
@@ -594,7 +596,7 @@ pub fn lighten_hsl(img: &mut PhotonImage, level: f32) {
 /// let mut img = open_image("img.jpg").expect("File should open");
 /// lighten_hsv(&mut img, 0.1_f32);
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn lighten_hsv(img: &mut PhotonImage, level: f32) {
     hsv(img, "lighten", level)
 }
@@ -617,7 +619,7 @@ pub fn lighten_hsv(img: &mut PhotonImage, level: f32) {
 /// let mut img = open_image("img.jpg").expect("File should open");
 /// darken_lch(&mut img, 0.1_f32);
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn darken_lch(img: &mut PhotonImage, level: f32) {
     lch(img, "darken", level)
 }
@@ -640,7 +642,7 @@ pub fn darken_lch(img: &mut PhotonImage, level: f32) {
 /// let mut img = open_image("img.jpg").expect("File should open");
 /// darken_hsluv(&mut img, 0.1_f32);
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn darken_hsluv(img: &mut PhotonImage, level: f32) {
     hsluv(img, "darken", level)
 }
@@ -663,7 +665,7 @@ pub fn darken_hsluv(img: &mut PhotonImage, level: f32) {
 /// let mut img = open_image("img.jpg").expect("File should open");
 /// darken_hsl(&mut img, 0.1_f32);
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn darken_hsl(img: &mut PhotonImage, level: f32) {
     hsl(img, "darken", level)
 }
@@ -686,7 +688,7 @@ pub fn darken_hsl(img: &mut PhotonImage, level: f32) {
 /// let mut img = open_image("img.jpg").expect("File should open");
 /// darken_hsv(&mut img, 0.1_f32);
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn darken_hsv(img: &mut PhotonImage, level: f32) {
     hsv(img, "darken", level)
 }
@@ -709,7 +711,7 @@ pub fn darken_hsv(img: &mut PhotonImage, level: f32) {
 /// let mut img = open_image("img.jpg").expect("File should open");
 /// desaturate_hsv(&mut img, 0.1_f32);
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn desaturate_hsv(img: &mut PhotonImage, level: f32) {
     hsv(img, "desaturate", level)
 }
@@ -732,7 +734,7 @@ pub fn desaturate_hsv(img: &mut PhotonImage, level: f32) {
 /// let mut img = open_image("img.jpg").expect("File should open");
 /// desaturate_hsl(&mut img, 0.1_f32);
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn desaturate_hsl(img: &mut PhotonImage, level: f32) {
     hsl(img, "desaturate", level)
 }
@@ -755,7 +757,7 @@ pub fn desaturate_hsl(img: &mut PhotonImage, level: f32) {
 /// let mut img = open_image("img.jpg").expect("File should open");
 /// desaturate_lch(&mut img, 0.1_f32);
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn desaturate_lch(img: &mut PhotonImage, level: f32) {
     lch(img, "desaturate", level)
 }
@@ -778,7 +780,7 @@ pub fn desaturate_lch(img: &mut PhotonImage, level: f32) {
 /// let mut img = open_image("img.jpg").expect("File should open");
 /// desaturate_hsluv(&mut img, 0.1_f32);
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn desaturate_hsluv(img: &mut PhotonImage, level: f32) {
     hsluv(img, "desaturate", level)
 }
@@ -806,7 +808,7 @@ pub fn desaturate_hsluv(img: &mut PhotonImage, level: f32) {
 /// let mut img = open_image("img.jpg").expect("File should open");
 /// mix_with_colour(&mut img, mix_colour, 0.4_f32);
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn mix_with_colour(photon_image: &mut PhotonImage, mix_colour: Rgb, opacity: f32) {
     let img = helpers::dyn_image_from_raw(photon_image);
     let (width, height) = img.dimensions();

--- a/crate/src/conv.rs
+++ b/crate/src/conv.rs
@@ -4,6 +4,8 @@ use crate::helpers;
 use crate::PhotonImage;
 use image::DynamicImage::ImageRgba8;
 use std::cmp::min;
+
+#[cfg(feature = "enable_wasm")]
 use wasm_bindgen::prelude::*;
 
 type Kernel = [f32; 9];
@@ -34,7 +36,7 @@ fn conv(photon_image: &mut PhotonImage, kernel: Kernel) {
 /// noise_reduction(&mut img);
 /// ```
 /// Adds a constant to a select R, G, or B channel's value.
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn noise_reduction(photon_image: &mut PhotonImage) {
     conv(
         photon_image,
@@ -58,7 +60,7 @@ pub fn noise_reduction(photon_image: &mut PhotonImage) {
 /// sharpen(&mut img);
 /// ```
 /// Adds a constant to a select R, G, or B channel's value.
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn sharpen(photon_image: &mut PhotonImage) {
     conv(
         photon_image,
@@ -81,7 +83,7 @@ pub fn sharpen(photon_image: &mut PhotonImage) {
 /// let mut img = open_image("img.jpg").expect("File should open");
 /// edge_detection(&mut img);
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn edge_detection(photon_image: &mut PhotonImage) {
     conv(
         photon_image,
@@ -104,7 +106,7 @@ pub fn edge_detection(photon_image: &mut PhotonImage) {
 /// let mut img = open_image("img.jpg").expect("File should open");
 /// identity(&mut img);
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn identity(photon_image: &mut PhotonImage) {
     conv(
         photon_image,
@@ -127,7 +129,7 @@ pub fn identity(photon_image: &mut PhotonImage) {
 /// let mut img = open_image("img.jpg").expect("File should open");
 /// box_blur(&mut img);
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn box_blur(photon_image: &mut PhotonImage) {
     conv(
         photon_image,
@@ -151,7 +153,7 @@ pub fn box_blur(photon_image: &mut PhotonImage) {
 /// let mut img = open_image("img.jpg").expect("File should open");
 /// gaussian_blur(&mut img, 3_i32);
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn gaussian_blur(photon_image: &mut PhotonImage, radius: i32) {
     // construct pixel data
     let img = helpers::dyn_image_from_raw(photon_image);
@@ -384,7 +386,7 @@ fn box_blur_vertical(
 /// let mut img = open_image("img.jpg").expect("File should open");
 /// detect_horizontal_lines(&mut img);
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn detect_horizontal_lines(photon_image: &mut PhotonImage) {
     conv(
         photon_image,
@@ -407,7 +409,7 @@ pub fn detect_horizontal_lines(photon_image: &mut PhotonImage) {
 /// let mut img = open_image("img.jpg").expect("File should open");
 /// detect_vertical_lines(&mut img);
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn detect_vertical_lines(photon_image: &mut PhotonImage) {
     conv(
         photon_image,
@@ -430,7 +432,7 @@ pub fn detect_vertical_lines(photon_image: &mut PhotonImage) {
 /// let mut img = open_image("img.jpg").expect("File should open");
 /// detect_45_deg_lines(&mut img);
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn detect_45_deg_lines(photon_image: &mut PhotonImage) {
     conv(
         photon_image,
@@ -453,7 +455,7 @@ pub fn detect_45_deg_lines(photon_image: &mut PhotonImage) {
 /// let mut img = open_image("img.jpg").expect("File should open");
 /// detect_135_deg_lines(&mut img);
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn detect_135_deg_lines(photon_image: &mut PhotonImage) {
     conv(
         photon_image,
@@ -476,7 +478,7 @@ pub fn detect_135_deg_lines(photon_image: &mut PhotonImage) {
 /// let mut img = open_image("img.jpg").expect("File should open");
 /// laplace(&mut img);
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn laplace(photon_image: &mut PhotonImage) {
     conv(
         photon_image,
@@ -499,7 +501,7 @@ pub fn laplace(photon_image: &mut PhotonImage) {
 /// let mut img = open_image("img.jpg").expect("File should open");
 /// edge_one(&mut img);
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn edge_one(photon_image: &mut PhotonImage) {
     conv(
         photon_image,
@@ -522,7 +524,7 @@ pub fn edge_one(photon_image: &mut PhotonImage) {
 /// let mut img = open_image("img.jpg").expect("File should open");
 /// emboss(&mut img);
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn emboss(photon_image: &mut PhotonImage) {
     conv(
         photon_image,
@@ -545,7 +547,7 @@ pub fn emboss(photon_image: &mut PhotonImage) {
 /// let mut img = open_image("img.jpg").expect("File should open");
 /// sobel_horizontal(&mut img);
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn sobel_horizontal(photon_image: &mut PhotonImage) {
     conv(
         photon_image,
@@ -568,7 +570,7 @@ pub fn sobel_horizontal(photon_image: &mut PhotonImage) {
 /// let mut img = open_image("img.jpg").expect("File should open");
 /// prewitt_horizontal(&mut img);
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn prewitt_horizontal(photon_image: &mut PhotonImage) {
     conv(
         photon_image,
@@ -591,7 +593,7 @@ pub fn prewitt_horizontal(photon_image: &mut PhotonImage) {
 /// let mut img = open_image("img.jpg").expect("File should open");
 /// sobel_vertical(&mut img);
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn sobel_vertical(photon_image: &mut PhotonImage) {
     conv(
         photon_image,

--- a/crate/src/effects.rs
+++ b/crate/src/effects.rs
@@ -11,6 +11,8 @@ use imageproc::rect::Rect;
 use perlin2d::PerlinNoise2D;
 use std::collections::HashMap;
 use std::f64;
+
+#[cfg(feature = "enable_wasm")]
 use wasm_bindgen::prelude::*;
 
 /// Adds an offset to the image by a certain number of pixels.
@@ -31,7 +33,7 @@ use wasm_bindgen::prelude::*;
 /// let mut img = open_image("img.jpg").expect("File should open");
 /// offset(&mut img, 0_usize, 30_u32);
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn offset(photon_image: &mut PhotonImage, channel_index: usize, offset: u32) {
     if channel_index > 2 {
         panic!("Invalid channel index passed. Channel1 must be equal to 0, 1, or 2.");
@@ -99,7 +101,7 @@ pub fn offset(photon_image: &mut PhotonImage, channel_index: usize, offset: u32)
 /// let mut img = open_image("img.jpg").expect("File should open");
 /// offset_red(&mut img, 30_u32);
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn offset_red(img: &mut PhotonImage, offset_amt: u32) {
     offset(img, 0, offset_amt)
 }
@@ -119,7 +121,7 @@ pub fn offset_red(img: &mut PhotonImage, offset_amt: u32) {
 /// let mut img = open_image("img.jpg").expect("File should open");
 /// offset_green(&mut img, 30_u32);
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn offset_green(img: &mut PhotonImage, offset_amt: u32) {
     offset(img, 1, offset_amt)
 }
@@ -139,7 +141,7 @@ pub fn offset_green(img: &mut PhotonImage, offset_amt: u32) {
 /// let mut img = open_image("img.jpg").expect("File should open");
 /// offset_blue(&mut img, 40_u32);
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn offset_blue(img: &mut PhotonImage, offset_amt: u32) {
     offset(img, 2, offset_amt)
 }
@@ -159,7 +161,7 @@ pub fn offset_blue(img: &mut PhotonImage, offset_amt: u32) {
 /// let mut img = open_image("img.jpg").expect("File should open");
 /// multiple_offsets(&mut img, 30_u32, 0_usize, 2_usize);
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn multiple_offsets(
     mut photon_image: &mut PhotonImage,
     offset: u32,
@@ -327,7 +329,7 @@ pub fn halftone(mut photon_image: &mut PhotonImage) {
 /// let mut img = open_image("img.jpg").expect("File should open");
 /// primary(&mut img);
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn primary(img: &mut PhotonImage) {
     let end = img.raw_pixels.len() - 4;
 
@@ -374,7 +376,7 @@ pub fn primary(img: &mut PhotonImage) {
 /// let mut img = open_image("img.jpg").expect("File should open");
 /// colorize(&mut img);
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn colorize(mut photon_image: &mut PhotonImage) {
     let mut img = helpers::dyn_image_from_raw(photon_image);
     let threshold = 220;
@@ -413,7 +415,7 @@ pub fn colorize(mut photon_image: &mut PhotonImage) {
     photon_image.raw_pixels = raw_pixels;
 }
 
-// #[wasm_bindgen]
+// #[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 // pub fn inc_luminosity(mut photon_image: PhotonImage) -> PhotonImage {
 //     let mut img = helpers::dyn_image_from_raw(photon_image);
 //     let (width, height) = img.dimensions();
@@ -476,7 +478,7 @@ pub fn colorize(mut photon_image: &mut PhotonImage) {
 /// let mut img = open_image("img.jpg").expect("File should open");
 /// solarize(&mut img);
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn solarize(photon_image: &mut PhotonImage) {
     let end = photon_image.get_raw_pixels().len();
 
@@ -504,7 +506,7 @@ pub fn solarize(photon_image: &mut PhotonImage) {
 /// let img = open_image("img.jpg").expect("File should open");
 /// let result: PhotonImage = solarize_retimg(&img);
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn solarize_retimg(photon_image: &PhotonImage) -> PhotonImage {
     let mut img = helpers::dyn_image_from_raw(photon_image);
 
@@ -539,7 +541,7 @@ pub fn solarize_retimg(photon_image: &PhotonImage) -> PhotonImage {
 /// let mut img = open_image("img.jpg").expect("File should open");
 /// inc_brightness(&mut img, 10_u8);
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn inc_brightness(photon_image: &mut PhotonImage, brightness: u8) {
     let end = photon_image.get_raw_pixels().len() - 4;
     for i in (0..end).step_by(4) {
@@ -581,7 +583,7 @@ pub fn inc_brightness(photon_image: &mut PhotonImage, brightness: u8) {
 /// let mut img = open_image("img.jpg").expect("File should open");
 /// adjust_contrast(&mut img, 30_f32);
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn adjust_contrast(mut photon_image: &mut PhotonImage, contrast: f32) {
     let mut img = helpers::dyn_image_from_raw(photon_image);
 
@@ -634,7 +636,7 @@ pub fn adjust_contrast(mut photon_image: &mut PhotonImage, contrast: f32) {
 /// tint(&mut img, 10_u32, 20_u32, 15_u32);
 /// ```
 ///
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn tint(
     mut photon_image: &mut PhotonImage,
     r_offset: u32,
@@ -714,7 +716,7 @@ fn draw_horizontal_strips(
 /// horizontal_strips(&mut img, 8u8);
 /// ```
 ///
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn horizontal_strips(photon_image: &mut PhotonImage, num_strips: u8) {
     let color = Rgb {
         r: 255,
@@ -743,7 +745,7 @@ pub fn horizontal_strips(photon_image: &mut PhotonImage, num_strips: u8) {
 /// color_horizontal_strips(&mut img, 8u8, color);
 /// ```
 ///
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn color_horizontal_strips(
     photon_image: &mut PhotonImage,
     num_strips: u8,
@@ -788,7 +790,7 @@ fn draw_vertical_strips(mut photon_image: &mut PhotonImage, num_strips: u8, colo
 /// vertical_strips(&mut img, 8u8);
 /// ```
 ///
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn vertical_strips(photon_image: &mut PhotonImage, num_strips: u8) {
     let color = Rgb {
         r: 255,
@@ -817,7 +819,7 @@ pub fn vertical_strips(photon_image: &mut PhotonImage, num_strips: u8) {
 /// color_vertical_strips(&mut img, 8u8, color);
 /// ```
 ///
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn color_vertical_strips(
     photon_image: &mut PhotonImage,
     num_strips: u8,
@@ -849,7 +851,7 @@ struct Intensity {
 /// oil(&mut img, 4i32, 55.0);
 /// ```
 ///
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn oil(mut photon_image: &mut PhotonImage, radius: i32, intensity: f64) {
     let img = helpers::dyn_image_from_raw(photon_image);
     let (width, height) = img.dimensions();
@@ -945,7 +947,7 @@ pub fn oil(mut photon_image: &mut PhotonImage, radius: i32, intensity: f64) {
 /// frosted_glass(&mut img);
 /// ```
 ///
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn frosted_glass(photon_image: &mut PhotonImage) {
     let img_orig_buf = photon_image.get_raw_pixels();
     let width = photon_image.get_width();
@@ -1000,7 +1002,7 @@ pub fn frosted_glass(photon_image: &mut PhotonImage) {
 /// pixelize(&mut img, 50);
 /// ```
 ///
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn pixelize(photon_image: &mut PhotonImage, pixel_size: i32) {
     let step_size = pixel_size.max(0) as usize;
     if step_size <= 1 {
@@ -1050,7 +1052,7 @@ pub fn pixelize(photon_image: &mut PhotonImage, pixel_size: i32) {
 /// normalize(&mut img);
 /// ```
 ///
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn normalize(photon_image: &mut PhotonImage) {
     let buf = photon_image.raw_pixels.as_mut_slice();
     let buf_size = buf.len();
@@ -1115,7 +1117,7 @@ pub fn normalize(photon_image: &mut PhotonImage) {
 /// dither(&mut img, depth);
 /// ```
 ///
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn dither(photon_image: &mut PhotonImage, depth: u32) {
     let width = photon_image.get_width() as usize;
     let height = photon_image.get_height() as usize;
@@ -1192,7 +1194,7 @@ fn create_gradient_map(color_a: Rgb, color_b: Rgb) -> Vec<Rgb> {
     gradient_map
 }
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn duotone(photon_image: &mut PhotonImage, color_a: Rgb, color_b: Rgb) {
     let gradient_map = create_gradient_map(color_a, color_b);
     let buf = photon_image.raw_pixels.as_mut_slice();

--- a/crate/src/filters.rs
+++ b/crate/src/filters.rs
@@ -6,6 +6,8 @@ use crate::colour_spaces::mix_with_colour;
 use crate::effects::{adjust_contrast, duotone, inc_brightness};
 use crate::monochrome;
 use crate::{PhotonImage, Rgb};
+
+#[cfg(feature = "enable_wasm")]
 use wasm_bindgen::prelude::*;
 
 /// Solarization on the Blue channel.
@@ -21,7 +23,7 @@ use wasm_bindgen::prelude::*;
 /// let mut img = open_image("img.jpg").expect("File should open");
 /// neue(&mut img);
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn neue(photon_image: &mut PhotonImage) {
     let end = photon_image.get_raw_pixels().len();
 
@@ -46,7 +48,7 @@ pub fn neue(photon_image: &mut PhotonImage) {
 /// let mut img = open_image("img.jpg").expect("File should open");
 /// lix(&mut img);
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn lix(photon_image: &mut PhotonImage) {
     let end = photon_image.get_raw_pixels().len();
 
@@ -72,7 +74,7 @@ pub fn lix(photon_image: &mut PhotonImage) {
 /// let mut img = open_image("img.jpg").expect("File should open");
 /// ryo(&mut img);
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn ryo(photon_image: &mut PhotonImage) {
     let end = photon_image.get_raw_pixels().len();
 
@@ -115,7 +117,7 @@ pub fn ryo(photon_image: &mut PhotonImage) {
 /// let mut img = open_image("img.jpg").expect("File should open");
 /// filter(&mut img, "vintage");
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn filter(img: &mut PhotonImage, filter_name: &str) {
     let oceanic_rgb = Rgb::new(0, 89, 173);
     let islands_rgb = Rgb::new(0, 24, 95);
@@ -169,7 +171,7 @@ pub fn filter(img: &mut PhotonImage, filter_name: &str) {
 /// let mut img = open_image("img.jpg").expect("File should open");
 /// lofi(&mut img);
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn lofi(img: &mut PhotonImage) {
     adjust_contrast(img, 30.0);
     colour_spaces::saturate_hsl(img, 0.2);
@@ -188,7 +190,7 @@ pub fn lofi(img: &mut PhotonImage) {
 /// let mut img = open_image("img.jpg").expect("File should open");
 /// pastel_pink(&mut img);
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn pastel_pink(img: &mut PhotonImage) {
     alter_channels(img, 80, 12, 20);
     adjust_contrast(img, 30.0);
@@ -207,7 +209,7 @@ pub fn pastel_pink(img: &mut PhotonImage) {
 /// let mut img = open_image("img.jpg").expect("File should open");
 /// golden(&mut img);
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn golden(img: &mut PhotonImage) {
     let vignette_rgb = Rgb::new(235, 145, 50);
     mix_with_colour(img, vignette_rgb, 0.2);
@@ -227,7 +229,7 @@ pub fn golden(img: &mut PhotonImage) {
 /// let mut img = open_image("img.jpg").expect("File should open");
 /// cali(&mut img);
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn cali(img: &mut PhotonImage) {
     let cali_rgb = Rgb::new(255, 45, 75);
     colour_spaces::mix_with_colour(img, cali_rgb, 0.1);
@@ -247,7 +249,7 @@ pub fn cali(img: &mut PhotonImage) {
 /// let mut img = open_image("img.jpg").expect("File should open");
 /// dramatic(&mut img);
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn dramatic(img: &mut PhotonImage) {
     monochrome::grayscale(img);
     adjust_contrast(img, 60.0);
@@ -269,7 +271,7 @@ pub fn dramatic(img: &mut PhotonImage) {
 /// let rgb_color = Rgb::new(12, 12, 10);
 /// monochrome_tint(&mut img, rgb_color);
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn monochrome_tint(img: &mut PhotonImage, rgb_color: Rgb) {
     monochrome::grayscale(img);
     mix_with_colour(img, rgb_color, 0.4);
@@ -289,7 +291,7 @@ pub fn monochrome_tint(img: &mut PhotonImage, rgb_color: Rgb) {
 /// let mut img = open_image("img.jpg").expect("File should open");
 /// duotone_violette(&mut img);
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn duotone_violette(img: &mut PhotonImage) {
     let rgb_color = Rgb::new(16, 228, 248);
     let rgb_color2 = Rgb::new(116, 54, 221);
@@ -309,7 +311,7 @@ pub fn duotone_violette(img: &mut PhotonImage) {
 /// let mut img = open_image("img.jpg").expect("File should open");
 /// duotone_horizon(&mut img);
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn duotone_horizon(img: &mut PhotonImage) {
     let rgb_color = Rgb::new(169, 167, 132);
     let rgb_color2 = Rgb::new(150, 24, 149);
@@ -333,7 +335,7 @@ pub fn duotone_horizon(img: &mut PhotonImage) {
 /// let rgb_color = Rgb::new(12, 12, 10);
 /// duotone_tint(&mut img, rgb_color);
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn duotone_tint(img: &mut PhotonImage, rgb_color: Rgb) {
     let rgb_color2 = Rgb::new(68, 61, 76);
     duotone(img, rgb_color, rgb_color2);
@@ -352,7 +354,7 @@ pub fn duotone_tint(img: &mut PhotonImage, rgb_color: Rgb) {
 /// let mut img = open_image("img.jpg").expect("File should open");
 /// duotone_lilac(&mut img);
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn duotone_lilac(img: &mut PhotonImage) {
     let rgb_color = Rgb::new(45, 3, 3);
     let rgb_color2 = Rgb::new(163, 134, 224);
@@ -372,7 +374,7 @@ pub fn duotone_lilac(img: &mut PhotonImage) {
 /// let mut img = open_image("img.jpg").expect("File should open");
 /// duotone_ochre(&mut img);
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn duotone_ochre(img: &mut PhotonImage) {
     let rgb_color = Rgb::new(25, 36, 88);
     let rgb_color2 = Rgb::new(236, 119, 0);
@@ -392,7 +394,7 @@ pub fn duotone_ochre(img: &mut PhotonImage) {
 /// let mut img = open_image("img.jpg").expect("File should open");
 /// firenze(&mut img);
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn firenze(img: &mut PhotonImage) {
     let cali_rgb = Rgb::new(255, 47, 78);
     colour_spaces::mix_with_colour(img, cali_rgb, 0.1);
@@ -414,7 +416,7 @@ pub fn firenze(img: &mut PhotonImage) {
 /// let mut img = open_image("img.jpg").expect("File should open");
 /// obsidian(&mut img);
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn obsidian(img: &mut PhotonImage) {
     monochrome::grayscale(img);
     adjust_contrast(img, 25.0);

--- a/crate/src/helpers.rs
+++ b/crate/src/helpers.rs
@@ -1,8 +1,8 @@
 //! Helper functions for converting between various formats
 
 use crate::{PhotonImage, Rgb};
-use image::{DynamicImage, ImageBuffer};
 use image::DynamicImage::ImageRgba8;
+use image::{DynamicImage, ImageBuffer};
 
 #[cfg(feature = "enable_wasm")]
 extern crate wasm_bindgen;

--- a/crate/src/helpers.rs
+++ b/crate/src/helpers.rs
@@ -2,8 +2,10 @@
 
 use crate::{PhotonImage, Rgb};
 use image::{DynamicImage, ImageBuffer};
-extern crate wasm_bindgen;
 use image::DynamicImage::ImageRgba8;
+
+#[cfg(feature = "enable_wasm")]
+extern crate wasm_bindgen;
 
 /// Gets the square distance between two colours
 pub fn square_distance(color1: Rgb, color2: Rgb) -> i32 {

--- a/crate/src/lib.rs
+++ b/crate/src/lib.rs
@@ -43,19 +43,25 @@ use base64::{decode, encode};
 use image::DynamicImage::ImageRgba8;
 use image::{GenericImage, GenericImageView};
 use serde::{Deserialize, Serialize};
+
+#[cfg(feature = "enable_wasm")]
 use wasm_bindgen::prelude::*;
+
+#[cfg(feature = "enable_wasm")]
 use wasm_bindgen::Clamped;
+
+#[cfg(feature = "enable_wasm")]
 use web_sys::{CanvasRenderingContext2d, HtmlCanvasElement, ImageData};
 
 // When the `wee_alloc` feature is enabled, use `wee_alloc` as the global
 // allocator.
-#[cfg(feature = "wee_alloc")]
+#[cfg(all(feature = "enable_wasm", feature = "wee_alloc"))]
 #[global_allocator]
 static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
 
 /// Provides the image's height, width, and contains the image's raw pixels.
 /// For use when communicating between JS and WASM, and also natively.
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct PhotonImage {
     raw_pixels: Vec<u8>,
@@ -63,9 +69,9 @@ pub struct PhotonImage {
     height: u32,
 }
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 impl PhotonImage {
-    #[wasm_bindgen(constructor)]
+    #[cfg_attr(feature = "enable_wasm", wasm_bindgen(constructor))]
     /// Create a new PhotonImage from a Vec of u8s, which represent raw pixels.
     pub fn new(raw_pixels: Vec<u8>, width: u32, height: u32) -> PhotonImage {
         PhotonImage {
@@ -161,6 +167,7 @@ impl PhotonImage {
     }
 
     /// Convert the PhotonImage's raw pixels to JS-compatible ImageData.
+    #[cfg(feature = "enable_wasm")]
     #[allow(clippy::unnecessary_mut_passed)]
     pub fn get_image_data(&mut self) -> ImageData {
         ImageData::new_with_u8_clamped_array_and_sh(
@@ -172,6 +179,7 @@ impl PhotonImage {
     }
 
     /// Convert ImageData to raw pixels, and update the PhotonImage's raw pixels to this.
+    #[cfg(feature = "enable_wasm")]
     pub fn set_imgdata(&mut self, img_data: ImageData) {
         let width = img_data.width();
         let height = img_data.height();
@@ -183,6 +191,7 @@ impl PhotonImage {
 }
 
 /// Create a new PhotonImage from a raw Vec of u8s representing raw image pixels.
+#[cfg(feature = "enable_wasm")]
 impl From<ImageData> for PhotonImage {
     fn from(imgdata: ImageData) -> Self {
         let width = imgdata.width();
@@ -197,7 +206,7 @@ impl From<ImageData> for PhotonImage {
 }
 
 /// RGB color type.
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Rgb {
     r: u8,
@@ -205,9 +214,9 @@ pub struct Rgb {
     b: u8,
 }
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 impl Rgb {
-    #[wasm_bindgen(constructor)]
+    #[cfg_attr(feature = "enable_wasm", wasm_bindgen(constructor))]
     /// Create a new RGB struct.
     pub fn new(r: u8, g: u8, b: u8) -> Rgb {
         Rgb { r, g, b }
@@ -254,7 +263,7 @@ impl From<Vec<u8>> for Rgb {
 }
 
 /// RGBA color type.
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Rgba {
     r: u8,
@@ -263,9 +272,9 @@ pub struct Rgba {
     a: u8,
 }
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 impl Rgba {
-    #[wasm_bindgen(constructor)]
+    #[cfg_attr(feature = "enable_wasm", wasm_bindgen(constructor))]
     /// Create a new RGBA struct.
     pub fn new(r: u8, g: u8, b: u8, a: u8) -> Rgba {
         Rgba { r, g, b, a }
@@ -322,7 +331,8 @@ impl From<Vec<u8>> for Rgba {
 }
 
 ///! [temp] Check if WASM is supported.
-#[wasm_bindgen]
+#[cfg(feature = "enable_wasm")]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn run() -> Result<(), JsValue> {
     set_panic_hook();
 
@@ -343,7 +353,8 @@ pub fn run() -> Result<(), JsValue> {
 }
 
 /// Get the ImageData from a 2D canvas context
-#[wasm_bindgen]
+#[cfg(feature = "enable_wasm")]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn get_image_data(
     canvas: &HtmlCanvasElement,
     ctx: &CanvasRenderingContext2d,
@@ -361,7 +372,8 @@ pub fn get_image_data(
 }
 
 /// Place a PhotonImage onto a 2D canvas.
-#[wasm_bindgen]
+#[cfg(feature = "enable_wasm")]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 #[allow(non_snake_case)]
 #[allow(clippy::unnecessary_mut_passed)]
 pub fn putImageData(
@@ -386,7 +398,8 @@ pub fn putImageData(
 ///
 /// This converts the ImageData found in the canvas context to a PhotonImage,
 /// which can then have effects or filters applied to it.
-#[wasm_bindgen]
+#[cfg(feature = "enable_wasm")]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 #[no_mangle]
 pub fn open_image(
     canvas: HtmlCanvasElement,
@@ -402,13 +415,14 @@ pub fn open_image(
 }
 
 /// Convert ImageData to a raw pixel vec of u8s.
-#[wasm_bindgen]
+#[cfg(feature = "enable_wasm")]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn to_raw_pixels(imgdata: ImageData) -> Vec<u8> {
     imgdata.data().to_vec()
 }
 
 /// Convert a base64 string to a PhotonImage.
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn base64_to_image(base64: &str) -> PhotonImage {
     let base64_to_vec: Vec<u8> = base64_to_vec(base64);
 
@@ -426,13 +440,14 @@ pub fn base64_to_image(base64: &str) -> PhotonImage {
 }
 
 /// Convert a base64 string to a Vec of u8s.
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn base64_to_vec(base64: &str) -> Vec<u8> {
     decode(base64).unwrap()
 }
 
 /// Convert a PhotonImage to JS-compatible ImageData.
-#[wasm_bindgen]
+#[cfg(feature = "enable_wasm")]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 #[allow(clippy::unnecessary_mut_passed)]
 pub fn to_image_data(photon_image: PhotonImage) -> ImageData {
     let mut raw_pixels = photon_image.raw_pixels;

--- a/crate/src/lib.rs
+++ b/crate/src/lib.rs
@@ -167,7 +167,7 @@ impl PhotonImage {
     }
 
     /// Convert the PhotonImage's raw pixels to JS-compatible ImageData.
-    #[cfg(feature = "enable_wasm")]
+    #[cfg(all(feature = "web-sys", feature = "wasm-bindgen"))]
     #[allow(clippy::unnecessary_mut_passed)]
     pub fn get_image_data(&mut self) -> ImageData {
         ImageData::new_with_u8_clamped_array_and_sh(

--- a/crate/src/lib.rs
+++ b/crate/src/lib.rs
@@ -47,15 +47,15 @@ use serde::{Deserialize, Serialize};
 #[cfg(feature = "enable_wasm")]
 use wasm_bindgen::prelude::*;
 
-#[cfg(feature = "enable_wasm")]
+#[cfg(feature = "wasm-bindgen")]
 use wasm_bindgen::Clamped;
 
-#[cfg(feature = "enable_wasm")]
+#[cfg(feature = "web-sys")]
 use web_sys::{CanvasRenderingContext2d, HtmlCanvasElement, ImageData};
 
 // When the `wee_alloc` feature is enabled, use `wee_alloc` as the global
 // allocator.
-#[cfg(all(feature = "enable_wasm", feature = "wee_alloc"))]
+#[cfg(feature = "wee_alloc")]
 #[global_allocator]
 static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
 
@@ -179,7 +179,7 @@ impl PhotonImage {
     }
 
     /// Convert ImageData to raw pixels, and update the PhotonImage's raw pixels to this.
-    #[cfg(feature = "enable_wasm")]
+    #[cfg(feature = "web-sys")]
     pub fn set_imgdata(&mut self, img_data: ImageData) {
         let width = img_data.width();
         let height = img_data.height();
@@ -191,7 +191,7 @@ impl PhotonImage {
 }
 
 /// Create a new PhotonImage from a raw Vec of u8s representing raw image pixels.
-#[cfg(feature = "enable_wasm")]
+#[cfg(feature = "web-sys")]
 impl From<ImageData> for PhotonImage {
     fn from(imgdata: ImageData) -> Self {
         let width = imgdata.width();
@@ -332,7 +332,7 @@ impl From<Vec<u8>> for Rgba {
 
 ///! [temp] Check if WASM is supported.
 #[cfg(feature = "enable_wasm")]
-#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
+#[wasm_bindgen]
 pub fn run() -> Result<(), JsValue> {
     set_panic_hook();
 
@@ -353,7 +353,7 @@ pub fn run() -> Result<(), JsValue> {
 }
 
 /// Get the ImageData from a 2D canvas context
-#[cfg(feature = "enable_wasm")]
+#[cfg(feature = "web-sys")]
 #[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn get_image_data(
     canvas: &HtmlCanvasElement,
@@ -372,7 +372,7 @@ pub fn get_image_data(
 }
 
 /// Place a PhotonImage onto a 2D canvas.
-#[cfg(feature = "enable_wasm")]
+#[cfg(all(feature = "web-sys", feature = "wasm-bindgen"))]
 #[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 #[allow(non_snake_case)]
 #[allow(clippy::unnecessary_mut_passed)]
@@ -398,7 +398,7 @@ pub fn putImageData(
 ///
 /// This converts the ImageData found in the canvas context to a PhotonImage,
 /// which can then have effects or filters applied to it.
-#[cfg(feature = "enable_wasm")]
+#[cfg(feature = "web-sys")]
 #[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 #[no_mangle]
 pub fn open_image(
@@ -415,7 +415,7 @@ pub fn open_image(
 }
 
 /// Convert ImageData to a raw pixel vec of u8s.
-#[cfg(feature = "enable_wasm")]
+#[cfg(feature = "web-sys")]
 #[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn to_raw_pixels(imgdata: ImageData) -> Vec<u8> {
     imgdata.data().to_vec()
@@ -446,7 +446,7 @@ pub fn base64_to_vec(base64: &str) -> Vec<u8> {
 }
 
 /// Convert a PhotonImage to JS-compatible ImageData.
-#[cfg(feature = "enable_wasm")]
+#[cfg(all(feature = "web-sys", feature = "wasm-bindgen"))]
 #[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 #[allow(clippy::unnecessary_mut_passed)]
 pub fn to_image_data(photon_image: PhotonImage) -> ImageData {

--- a/crate/src/monochrome.rs
+++ b/crate/src/monochrome.rs
@@ -5,6 +5,8 @@ use crate::iter::ImageIterator;
 use crate::PhotonImage;
 use image::Pixel;
 use image::{GenericImage, GenericImageView};
+
+#[cfg(feature = "enable_wasm")]
 use wasm_bindgen::prelude::*;
 
 /// Apply a monochrome effect of a certain colour.
@@ -28,7 +30,7 @@ use wasm_bindgen::prelude::*;
 /// monochrome(&mut img, 40_u32, 50_u32, 100_u32);
 /// ```
 ///
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn monochrome(img: &mut PhotonImage, r_offset: u32, g_offset: u32, b_offset: u32) {
     let end = img.get_raw_pixels().len();
 
@@ -77,7 +79,7 @@ pub fn monochrome(img: &mut PhotonImage, r_offset: u32, g_offset: u32, b_offset:
 /// sepia(&mut img);
 /// ```
 ///
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn sepia(img: &mut PhotonImage) {
     let end = img.get_raw_pixels().len();
 
@@ -120,7 +122,7 @@ pub fn sepia(img: &mut PhotonImage) {
 /// let mut img = open_image("img.jpg").expect("File should open");
 /// grayscale(&mut img);
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn grayscale(img: &mut PhotonImage) {
     let end = img.get_raw_pixels().len();
 
@@ -154,7 +156,7 @@ pub fn grayscale(img: &mut PhotonImage) {
 /// let mut img = open_image("img.jpg").expect("File should open");
 /// grayscale_human_corrected(&mut img);
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn grayscale_human_corrected(img: &mut PhotonImage) {
     let end = img.get_raw_pixels().len();
 
@@ -186,7 +188,7 @@ pub fn grayscale_human_corrected(img: &mut PhotonImage) {
 /// let mut img = open_image("img.jpg").expect("File should open");
 /// desaturate(&mut img);
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn desaturate(img: &mut PhotonImage) {
     let end = img.get_raw_pixels().len();
 
@@ -222,7 +224,7 @@ pub fn desaturate(img: &mut PhotonImage) {
 /// let mut img = open_image("img.jpg").expect("File should open");
 /// decompose_min(&mut img);
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn decompose_min(img: &mut PhotonImage) {
     let end = img.get_raw_pixels().len();
 
@@ -258,7 +260,7 @@ pub fn decompose_min(img: &mut PhotonImage) {
 /// let mut img = open_image("img.jpg").expect("File should open");
 /// decompose_max(&mut img);
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn decompose_max(img: &mut PhotonImage) {
     let end = img.get_raw_pixels().len();
 
@@ -295,7 +297,7 @@ pub fn decompose_max(img: &mut PhotonImage) {
 /// let mut img = open_image("img.jpg").expect("File should open");
 /// grayscale_shades(&mut img, 4_u8);
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn grayscale_shades(mut photon_image: &mut PhotonImage, num_shades: u8) {
     let mut img = helpers::dyn_image_from_raw(photon_image);
 
@@ -333,7 +335,7 @@ pub fn grayscale_shades(mut photon_image: &mut PhotonImage, num_shades: u8) {
 /// let mut img = open_image("img.jpg").expect("File should open");
 /// r_grayscale(&mut img);
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn r_grayscale(photon_image: &mut PhotonImage) {
     single_channel_grayscale(photon_image, 0)
 }
@@ -352,7 +354,7 @@ pub fn r_grayscale(photon_image: &mut PhotonImage) {
 /// let mut img = open_image("img.jpg").expect("File should open");
 /// g_grayscale(&mut img);
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn g_grayscale(photon_image: &mut PhotonImage) {
     single_channel_grayscale(photon_image, 1)
 }
@@ -371,7 +373,7 @@ pub fn g_grayscale(photon_image: &mut PhotonImage) {
 /// let mut img = open_image("img.jpg").expect("File should open");
 /// b_grayscale(&mut img);
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn b_grayscale(photon_image: &mut PhotonImage) {
     single_channel_grayscale(photon_image, 2)
 }
@@ -391,7 +393,7 @@ pub fn b_grayscale(photon_image: &mut PhotonImage) {
 /// let mut img = open_image("img.jpg").expect("File should open");
 /// single_channel_grayscale(&mut img, 0_usize);
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn single_channel_grayscale(mut photon_image: &mut PhotonImage, channel: usize) {
     let mut img = helpers::dyn_image_from_raw(photon_image);
 
@@ -426,7 +428,7 @@ pub fn single_channel_grayscale(mut photon_image: &mut PhotonImage, channel: usi
 /// let mut img = open_image("img.jpg").expect("File should open");
 /// threshold(&mut img, 30_u32);
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn threshold(img: &mut PhotonImage, threshold: u32) {
     let end = img.get_raw_pixels().len();
 

--- a/crate/src/multiple.rs
+++ b/crate/src/multiple.rs
@@ -9,6 +9,8 @@ use image::{DynamicImage, GenericImageView, RgbaImage};
 use palette::{Blend, Gradient, Lab, Lch, LinSrgba, Srgb, Srgba};
 use palette::{FromColor, IntoColor};
 use std::cmp::{max, min};
+
+#[cfg(feature = "enable_wasm")]
 use wasm_bindgen::prelude::*;
 
 /// Add a watermark to an image.
@@ -29,7 +31,7 @@ use wasm_bindgen::prelude::*;
 /// let water_mark = open_image("watermark.jpg").expect("File should open");
 /// watermark(&mut img, &water_mark, 30_u32, 40_u32);
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn watermark(mut img: &mut PhotonImage, watermark: &PhotonImage, x: u32, y: u32) {
     let dyn_watermark: DynamicImage = crate::helpers::dyn_image_from_raw(watermark);
     let mut dyn_img: DynamicImage = crate::helpers::dyn_image_from_raw(img);
@@ -60,7 +62,7 @@ pub fn watermark(mut img: &mut PhotonImage, watermark: &PhotonImage, x: u32, y: 
 /// let img2 = open_image("img2.jpg").expect("File should open");
 /// blend(&mut img, &img2, "multiply");
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn blend(
     mut photon_image: &mut PhotonImage,
     photon_image2: &PhotonImage,
@@ -140,7 +142,7 @@ pub fn blend(
     photon_image.raw_pixels = dynimage.to_bytes();
 }
 
-// #[wasm_bindgen]
+// #[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 // pub fn blend_img_browser(
 //     source_canvas: HtmlCanvasElement,
 //     overlay_img: HtmlImageElement,
@@ -216,7 +218,7 @@ pub fn replace_background(
     photon_image.raw_pixels = raw_pixels;
 }
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn create_gradient(width: u32, height: u32) -> PhotonImage {
     let mut image = RgbaImage::new(width, height);
 
@@ -262,7 +264,7 @@ pub fn create_gradient(width: u32, height: u32) -> PhotonImage {
 }
 
 /// Apply a gradient to an image.
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn apply_gradient(image: &mut PhotonImage) {
     let gradient = create_gradient(image.width, image.height);
 

--- a/crate/src/text.rs
+++ b/crate/src/text.rs
@@ -9,6 +9,8 @@ use imageproc::distance_transform::Norm;
 use imageproc::drawing::draw_text_mut;
 use imageproc::morphology::dilate_mut;
 use rusttype::{Font, Scale};
+
+#[cfg(feature = "enable_wasm")]
 use wasm_bindgen::prelude::*;
 
 /// Add bordered-text to an image.
@@ -32,7 +34,7 @@ use wasm_bindgen::prelude::*;
 /// let mut img = open_image("img.jpg").expect("File should open");
 /// draw_text_with_border(&mut img, "Welcome to Photon!", 10_u32, 10_u32);
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn draw_text_with_border(
     mut photon_img: &mut PhotonImage,
     text: &str,
@@ -107,7 +109,7 @@ pub fn draw_text_with_border(
 /// let mut img = open_image("img.jpg").expect("File should open");
 /// draw_text(&mut img, "Welcome to Photon!", 10_u32, 10_u32);
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn draw_text(mut photon_img: &mut PhotonImage, text: &str, x: u32, y: u32) {
     let mut image = helpers::dyn_image_from_raw(photon_img).to_rgba8();
 

--- a/crate/src/transform.rs
+++ b/crate/src/transform.rs
@@ -9,11 +9,12 @@ use image::RgbaImage;
 use image::{GenericImageView, ImageBuffer};
 use std::cmp::max;
 use std::cmp::min;
-use wasm_bindgen::prelude::*;
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(feature = "enable_wasm")]
+use wasm_bindgen::prelude::*;
+#[cfg(all(feature = "enable_wasm", target_arch = "wasm32"))]
 use wasm_bindgen::{Clamped, JsCast};
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "enable_wasm", target_arch = "wasm32"))]
 use web_sys::{HtmlCanvasElement, ImageData};
 
 /// Crop an image.
@@ -33,7 +34,7 @@ use web_sys::{HtmlCanvasElement, ImageData};
 /// let cropped_img: PhotonImage = crop(&mut img, 0_u32, 0_u32, 500_u32, 800_u32);
 /// // Write the contents of this image in JPG format.
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn crop(
     photon_image: &mut PhotonImage,
     x1: u32,
@@ -59,7 +60,7 @@ pub fn crop(
 }
 
 #[cfg(target_arch = "wasm32")]
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn crop_img_browser(
     source_canvas: HtmlCanvasElement,
     width: f64,
@@ -115,7 +116,7 @@ pub fn crop_img_browser(
 /// let mut img = open_image("img.jpg").expect("File should open");
 /// fliph(&mut img);
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn fliph(photon_image: &mut PhotonImage) {
     let img = helpers::dyn_image_from_raw(photon_image);
 
@@ -148,7 +149,7 @@ pub fn fliph(photon_image: &mut PhotonImage) {
 /// let mut img = open_image("img.jpg").expect("File should open");
 /// flipv(&mut img);
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn flipv(photon_image: &mut PhotonImage) {
     let img = helpers::dyn_image_from_raw(photon_image);
 
@@ -167,7 +168,7 @@ pub fn flipv(photon_image: &mut PhotonImage) {
     photon_image.raw_pixels = raw_pixels;
 }
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub enum SamplingFilter {
     Nearest = 1,
     Triangle = 2,
@@ -194,7 +195,7 @@ fn filter_type_from_sampling_filter(sampling_filter: SamplingFilter) -> FilterTy
 /// * `height` - New height.
 /// * `sampling_filter` - Nearest = 1, Triangle = 2, CatmullRom = 3, Gaussian = 4, Lanczos3 = 5
 #[cfg(target_arch = "wasm32")]
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn resize_img_browser(
     photon_img: &PhotonImage,
     width: u32,
@@ -248,7 +249,7 @@ pub fn resize_img_browser(
 /// * `width` - New width.
 /// * `height` - New height.
 /// * `sampling_filter` - Nearest = 1, Triangle = 2, CatmullRom = 3, Gaussian = 4, Lanczos3 = 5
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn resize(
     photon_img: &PhotonImage,
     width: u32,
@@ -292,7 +293,7 @@ pub fn resize(
 /// let img = open_image("img.jpg").expect("File should open");
 /// let result: PhotonImage = seam_carve(&img, 100_u32, 100_u32);
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn seam_carve(img: &PhotonImage, width: u32, height: u32) -> PhotonImage {
     let mut img: RgbaImage = ImageBuffer::from_raw(
         img.get_width(),
@@ -344,7 +345,7 @@ pub fn seam_carve(img: &PhotonImage, width: u32, height: u32) -> PhotonImage {
 /// let rgba = Rgba::new(200_u8, 100_u8, 150_u8, 255_u8);
 /// padding_uniform(&img, 10_u32, rgba);
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn padding_uniform(
     img: &PhotonImage,
     padding: u32,
@@ -409,7 +410,7 @@ pub fn padding_uniform(
 /// let rgba = Rgba::new(200_u8, 100_u8, 150_u8, 255_u8);
 /// padding_left(&img, 10_u32, rgba);
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn padding_left(img: &PhotonImage, padding: u32, padding_rgba: Rgba) -> PhotonImage {
     let image_buffer = img.get_raw_pixels();
     let img_width = img.get_width();
@@ -455,7 +456,7 @@ pub fn padding_left(img: &PhotonImage, padding: u32, padding_rgba: Rgba) -> Phot
 /// let rgba = Rgba::new(200_u8, 100_u8, 150_u8, 255_u8);
 /// padding_right(&img, 10_u32, rgba);
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn padding_right(
     img: &PhotonImage,
     padding: u32,
@@ -504,7 +505,7 @@ pub fn padding_right(
 /// let rgba = Rgba::new(200_u8, 100_u8, 150_u8, 255_u8);
 /// padding_top(&img, 10_u32, rgba);
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn padding_top(img: &PhotonImage, padding: u32, padding_rgba: Rgba) -> PhotonImage {
     let image_buffer = img.get_raw_pixels();
     let img_width = img.get_width();
@@ -549,7 +550,7 @@ pub fn padding_top(img: &PhotonImage, padding: u32, padding_rgba: Rgba) -> Photo
 /// let rgba = Rgba::new(200_u8, 100_u8, 150_u8, 255_u8);
 /// padding_bottom(&img, 10_u32, rgba);
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn padding_bottom(
     img: &PhotonImage,
     padding: u32,
@@ -597,7 +598,7 @@ pub fn padding_bottom(
 /// let img = open_image("img.jpg").expect("File should open");
 /// let rotated_img = rotate(&img, 30);
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn rotate(img: &PhotonImage, angle: i32) -> PhotonImage {
     // 390, 750 and 30 degrees represent the same angle. Trim 360.
     let full_circle_count = angle / 360;
@@ -762,7 +763,7 @@ fn copy_row(buf: &[u8], row_pos: usize, row_stride: usize) -> Vec<u8> {
 /// let img = open_image("img.jpg").expect("File should open");
 /// let rotated_img = resample(&img, 1920, 1080);
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn resample(img: &PhotonImage, dst_width: usize, dst_height: usize) -> PhotonImage {
     let mut pix_buf = Vec::<u8>::new();
     if dst_width == 0 || dst_height == 0 {


### PR DESCRIPTION
> **TL;DR:** use the feature `enable_wasm = false` to skip compilation of all WASM-only dependencies and functionality.

## Motivation

### Use case #⁠1: Using Photon as a pure Rust dependency

Some users may wish to make use of the excellent filters and image processing in a pure Rust project. In these cases, they can avoid the build time and overhead from WASM dependencies, like in the case of #147. Providing a single feature flag `enable_wasm = false` makes this very convenient for them.

### Use case #⁠2: Re-exporting a subset of WASM functionality

Sometimes Photon is used as a dependency of another package that itself is compiled into WASM, like in the case of [`hypetrigger`](https://github.com/nathanbabcock/hypetrigger). There is no such thing as tree-shaking the compiled WASM bundle (yet), and the full-size Photon bundle can be relatively large and include methods that are never used in the downstream library. The problem is that running `wasm-pack` will pick up every single `#[wasm-bindgen]` attribute, even the ones inside of a crate's dependencies, making it very hard to separate out. Adding `enable_wasm = false` supports this use case as well, as the downstream library can simple re-export the methods they need, manually adding `#[wasm-bindgen]` where needed.

## Summary of Changes

### Introduce a new `enable_wasm` feature.

- It is **enabled** by default.
- It is **additive**, as [recommended](https://doc.rust-lang.org/cargo/reference/features.html?highlight=additive#feature-unification) in the Cargo manual.
- It is **backwards compatible**, since the default behavior is the same as before this PR.

### Make WASM dependencies optional.

- When `enable_wasm` is **TRUE** (the default), all WASM dependencies will be installed:
	- `wasm-bindgen`
	- `web-sys`
	- `js-sys`
	- `node-sys`
	- `console_error_panic_hook`
	- `wee_alloc`
- On any `use` statement involving these dependencies, add a conditional compilation flag: `#[cfg(feature = "enable_wasm")]`
- When `enable_wasm` is **FALSE**, all the above deps will be skipped. Resolves #147.

### Make all `wasm_bindgen` attributes conditional.

- Before: `#[wasm_bindgen]`
- After: `#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]`

### Make all `web_sys` methods optional.

- Turning off `enable_wasm` will skip the optional import of `web-sys`.
- When `web-sys` is not included, the following methods will be skipped as well, since they depend on objects like `Canvas`, `ImageData`, and `CanvasRenderingContext2D`:
	- `PhotonImage::get_image_data`
	- `PhotonImage::set_imgdata`
	- `PhotonImage::From<ImageData>`
	- `run` (WASM entrypoint inside `lib.rs`)
	- `get_image_data`
	- `to_image_data`
	- `putImageData`
	- `open_image`
	- `to_raw_pixels`
- _Note:_ It's possible to enable `web-sys` independently, in order to make use of these methods without generating WASM bindings for them.

## Testing

All tests are **passing** under three different configurations of features:

```sh
# Default settings (WASM enabled)
cargo test

# WASM disabled
cargo test --no-default-features

# Granular custom configuration: `wasm-bindgen` disabled, but `web-sys` methods still compiled.
cargo test --no-default-features --features=web-sys

```

---

@silvia-odwyer Please take your time and let me know what you think of the proposed changes. My goal is that this feature is completely unobtrusive to any existing functionality. Please let me know if  you notice any edge cases I've overlooked! 😀