### PR TITLE
fix GitHub workflow badge URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   [![GitHub Issues](https://img.shields.io/github/issues/silvia-odwyer/photon.svg?style=for-the-badge&logo=github)](https://github.com/silvia-odwyer/photon/issues)
   [![Gitter Chat](https://img.shields.io/gitter/room/silvia-odwyer/photon?color=cyan&logo=Gitter&style=for-the-badge)](https://gitter.im/photonlibrary/community "Gitter chat")
   [![NPM Monthly Downloads](https://img.shields.io/npm/dm/@silvia-odwyer/photon?logo=npm&style=for-the-badge&color=pink)](https://www.npmjs.com/package/@silvia-odwyer/photon)
-  [![GitHub Workflow Status](https://img.shields.io/github/workflow/status/silvia-odwyer/photon/Continuous%20Integration?logo=github&style=for-the-badge)](https://github.com/silvia-odwyer/photon/blob/master/.github/workflows/compile_wasm.yaml)
+  [![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/silvia-odwyer/photon/ci.yml?branch=master&logo=github&style=for-the-badge)](https://github.com/silvia-odwyer/photon/blob/master/.github/workflows/compile_wasm.yaml)
 
   [![Crates.io](https://img.shields.io/crates/v/photon_rs?logo=rust&style=for-the-badge)](https://crates.io/crates/photon_rs)
   [![License](https://img.shields.io/github/license/silvia-odwyer/photon?style=for-the-badge)](https://github.com/silvia-odwyer/photon/blob/master/LICENSE.md)


### PR DESCRIPTION
fix GitHub workflow badge URL.

See https://github.com/badges/shields/issues/8671

> You need to update your badge URL from
> https://img.shields.io/github/workflow/status/<user>/<repo>/Run%20Tests
> to
> https://img.shields.io/github/actions/workflow/status/<user>/<repo>/test.yml?branch=main