### PR TITLE
#145 - Some convolution filters are not working

### DIFF
--- a/crate/src/conv.rs
+++ b/crate/src/conv.rs
@@ -2,8 +2,8 @@
 
 use crate::helpers;
 use crate::PhotonImage;
-use image::{GenericImage, GenericImageView, Pixel};
 use image::DynamicImage::ImageRgba8;
+use image::{GenericImage, GenericImageView, Pixel};
 use std::cmp::min;
 
 #[cfg(feature = "enable_wasm")]
@@ -18,11 +18,12 @@ fn conv(photon_image: &mut PhotonImage, kernel: Kernel) {
     let mut filtered_img = img.filter3x3(&kernel);
     filtered_img = ImageRgba8(filtered_img.to_rgba8());
 
-    if filtered_img.pixels().all(|p|  p.2[3] == 0 ) {
+    if filtered_img.pixels().all(|p| p.2[3] == 0) {
         for x in 0..GenericImageView::width(&img) - 1 {
             for y in 0..GenericImageView::height(&img) - 1 {
                 let mut pixel = GenericImageView::get_pixel(&filtered_img, x, y);
-                let original_alpha = GenericImageView::get_pixel(&img, x, y).channels()[3];
+                let original_alpha =
+                    GenericImageView::get_pixel(&img, x, y).channels()[3];
                 pixel.channels_mut()[3] = original_alpha;
                 filtered_img.put_pixel(x, y, pixel);
             }

--- a/crate/src/conv.rs
+++ b/crate/src/conv.rs
@@ -2,6 +2,7 @@
 
 use crate::helpers;
 use crate::PhotonImage;
+use image::{GenericImage, GenericImageView, Pixel};
 use image::DynamicImage::ImageRgba8;
 use std::cmp::min;
 
@@ -16,6 +17,17 @@ fn conv(photon_image: &mut PhotonImage, kernel: Kernel) {
 
     let mut filtered_img = img.filter3x3(&kernel);
     filtered_img = ImageRgba8(filtered_img.to_rgba8());
+
+    if filtered_img.pixels().all(|p|  p.2[3] == 0 ) {
+        for x in 0..GenericImageView::width(&img) - 1 {
+            for y in 0..GenericImageView::height(&img) - 1 {
+                let mut pixel = GenericImageView::get_pixel(&filtered_img, x, y);
+                let original_alpha = GenericImageView::get_pixel(&img, x, y).channels()[3];
+                pixel.channels_mut()[3] = original_alpha;
+                filtered_img.put_pixel(x, y, pixel);
+            }
+        }
+    }
 
     photon_image.raw_pixels = filtered_img.to_bytes();
 }


### PR DESCRIPTION
Applying some of these convolution filters to a fully opaque image will set the alpha channel to full transparent, as described here: https://stackoverflow.com/a/70429242

With this approach, when the image would be rendered fully transparent (all alpha values are 0), restore the alpha to the original value.