### PR TITLE
Add support building for `wasm32-wasi` targets.

### DIFF
--- a/crate/src/lib.rs
+++ b/crate/src/lib.rs
@@ -516,6 +516,7 @@ pub fn to_image_data(photon_image: PhotonImage) -> ImageData {
         .unwrap()
 }
 
+#[cfg(not(target_os = "wasi"))]
 fn set_panic_hook() {
     // When the `console_error_panic_hook` feature is enabled, we can call the
     // `set_panic_hook` function to get better error messages if we ever panic.

--- a/crate/src/noise.rs
+++ b/crate/src/noise.rs
@@ -10,10 +10,10 @@ use crate::PhotonImage;
 #[cfg(feature = "enable_wasm")]
 use wasm_bindgen::prelude::*;
 
-#[cfg(target_family = "wasm")]
+#[cfg(all(target_family = "wasm", not(target_os = "wasi")))]
 use js_sys::Math::random;
 
-#[cfg(not(target_family = "wasm"))]
+#[cfg(not(all(target_arch = "wasm", not(target_os = "wasi"))))]
 use rand::Rng;
 
 /// Add randomized noise to an image.
@@ -39,14 +39,14 @@ use rand::Rng;
 pub fn add_noise_rand(photon_image: &mut PhotonImage) {
     let mut img = helpers::dyn_image_from_raw(photon_image);
 
-    #[cfg(not(target_family = "wasm"))]
+    #[cfg(not(all(target_arch = "wasm", not(target_os = "wasi"))))]
     let mut rng = rand::thread_rng();
 
     for (x, y) in ImageIterator::with_dimension(&img.dimensions()) {
-        #[cfg(not(target_family = "wasm"))]
+        #[cfg(not(all(target_arch = "wasm", not(target_os = "wasi"))))]
         let offset = rng.gen_range(0, 150);
 
-        #[cfg(target_family = "wasm")]
+        #[cfg(all(target_arch = "wasm", not(target_os = "wasi")))]
         let offset = (random() * 150.0) as u8;
 
         let px =
@@ -84,13 +84,13 @@ pub fn add_noise_rand(photon_image: &mut PhotonImage) {
 #[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn pink_noise(photon_image: &mut PhotonImage) {
     let mut img = helpers::dyn_image_from_raw(photon_image);
-    #[cfg(not(target_family = "wasm"))]
+    #[cfg(not(all(target_arch = "wasm", not(target_os = "wasi"))))]
     let mut rng = rand::thread_rng();
 
-    #[cfg(not(target_family = "wasm"))]
+    #[cfg(not(all(target_arch = "wasm", not(target_os = "wasi"))))]
     let mut rng_gen = move || rng.gen();
 
-    #[cfg(target_family = "wasm")]
+    #[cfg(all(target_arch = "wasm", not(target_os = "wasi")))]
     let rng_gen = || random();
 
     for (x, y) in ImageIterator::with_dimension(&img.dimensions()) {

--- a/crate/src/transform.rs
+++ b/crate/src/transform.rs
@@ -63,7 +63,7 @@ pub fn crop(
     }
 }
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
 #[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn crop_img_browser(
     source_canvas: HtmlCanvasElement,
@@ -198,7 +198,7 @@ fn filter_type_from_sampling_filter(sampling_filter: SamplingFilter) -> FilterTy
 /// * `width` - New width.
 /// * `height` - New height.
 /// * `sampling_filter` - Nearest = 1, Triangle = 2, CatmullRom = 3, Gaussian = 4, Lanczos3 = 5
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
 #[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
 pub fn resize_img_browser(
     photon_img: &PhotonImage,


### PR DESCRIPTION
This PR adds the ability to compile for `wasm32-wasi` target. I was attempting to build an app using [Spin](https://github.com/fermyon/spin). An example application can be found [here](https://github.com/karthik2804/photon-image).

I am happy to update CI to test for the `wasm32-wasi` target as well. 