### PR TITLE
Implement Bayer dither, film grain, and vignette effects

### DIFF
--- a/crate/src/effects.rs
+++ b/crate/src/effects.rs
@@ -1246,6 +1246,85 @@ pub fn dither(photon_image: &mut PhotonImage, depth: u32) {
     }
 }
 
+/// Bayer ordered dithering LUT
+static BAYER_8X8: [[u8; 8]; 8] = [
+    [  0,  32,   8,  40,   2,  34,  10,  42],
+    [ 48,  16,  56,  24,  50,  18,  58,  26],
+    [ 12,  44,   4,  36,  14,  46,   6,  38],
+    [ 60,  28,  52,  20,  62,  30,  54,  22],
+    [  3,  35,  11,  43,   1,  33,   9,  41],
+    [ 51,  19,  59,  27,  49,  17,  57,  25],
+    [ 15,  47,   7,  39,  13,  45,   5,  37],
+    [ 63,  31,  55,  23,  61,  29,  53,  21],
+];
+
+/// Apply Bayer ordered dithering to an image.
+///
+/// Ordered dithering quantizes each pixel's colour channels independently by
+/// comparing the channel value (plus a spatially-varying threshold from the
+/// 8×8 Bayer matrix) against the nearest quantization level.  Unlike
+/// Floyd-Steinberg error diffusion, every pixel is processed in isolation,
+/// making this algorithm branch-free and cache-friendly.
+///
+/// # Arguments
+/// * `photon_image` - A mutable reference to the [`PhotonImage`] to process.
+/// * `bit_depth`    - Target bits per channel (clamped to 1–8).  
+///                    `1` → 2 levels (pure black/white per channel),  
+///                    `4` → 16 levels, `8` → no quantization.
+/// * `spread`       - Dithering spread in the range `[0.0, 1.0]`.  
+///                    `1.0` is the canonical Bayer threshold; lower values
+///                    reduce the visible halftone pattern for a subtler look.
+///
+/// # Example
+///
+/// ```no_run
+/// use photon_rs::effects::bayer_dither;
+/// use photon_rs::native::open_image;
+///
+/// let mut img = open_image("img.jpg").expect("File should open");
+/// // 2-bit depth, full Bayer spread — strong ordered dither
+/// bayer_dither(&mut img, 2, 1.0);
+/// ```
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
+pub fn bayer_dither(photon_image: &mut PhotonImage, bit_depth: u32, spread: f32) {
+    let depth   = bit_depth.clamp(1,8);
+    let spread  = spread.clamp(0.0,1.0);
+
+    let levels   = (1u32 << depth) as f32;
+    let step     = 255.0_f32 /(levels-1.0);
+    let inv_step = 1.0_f32 /step;
+
+    // `half_spread` shifts the threshold so that the Bayer bias is centred
+    // around zero: threshold values map from [-127.5*spread, +127.5*spread].
+    // Multiplying by `spread` here means the user can dial down the dithering
+    // without any extra work in the pixel loop.
+    let half_spread = 127.5_f32 * spread;
+
+    let width = photon_image.get_width() as usize;
+    let buf   = photon_image.raw_pixels.as_mut_slice();
+    let end   = buf.len();
+
+    let mut x: usize = 0;
+    let mut y: usize = 0;
+
+    for i in (0..end).step_by(4) {
+        // BAYER_8X8 stores values in [0, 63]; scale to a signed bias in [-half_spread, +half_spread].
+        let raw_threshold = BAYER_8X8[y&7][x&7] as f32; // 0.0 – 63.0
+        let bias =(raw_threshold /63.0-0.5) *2.0 *half_spread;
+
+        let r = buf[i]   as f32;
+        let g = buf[i+1] as f32;
+        let b = buf[i+2] as f32;
+
+        buf[i]   =(((r+bias) *inv_step +0.5).floor() *step).clamp(0.0, 255.0) as u8;
+        buf[i+1] =(((g+bias) *inv_step +0.5).floor() *step).clamp(0.0, 255.0) as u8;
+        buf[i+2] =(((b+bias) *inv_step +0.5).floor() *step).clamp(0.0, 255.0) as u8;
+
+        x +=1;
+        if x == width { x = 0; y += 1;}
+    }
+}
+
 fn create_gradient_map(color_a: Rgb, color_b: Rgb) -> Vec<Rgb> {
     let mut gradient_map = vec![Rgb::new(0, 0, 0); 256];
 
@@ -1279,5 +1358,62 @@ pub fn duotone(photon_image: &mut PhotonImage, color_a: Rgb, color_b: Rgb) {
         px[0] = mapped_luma.r;
         px[1] = mapped_luma.g;
         px[2] = mapped_luma.b;
+    }
+}
+
+/// Apply a radial vignette effect to an image.
+///
+/// # Example
+///
+/// ```no_run
+/// use photon_rs::effects::vignette;
+/// use photon_rs::native::open_image;
+///
+/// let mut img = open_image("img.jpg").expect("File should open");
+/// // Moderate vignette — corners darken by ~60 %
+/// vignette(&mut img, 0.6);
+/// ```
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
+pub fn vignette(photon_image: &mut PhotonImage, intensity: f32) {
+    let intensity = intensity.clamp(0.0, 1.0);
+
+    if intensity == 0.0 {
+        return;
+    }
+
+    let width  = photon_image.get_width()  as usize;
+    let height = photon_image.get_height() as usize;
+
+    let cx = (width  / 2) as i64;
+    let cy = (height / 2) as i64;
+ 
+    let corner_dx = cx;
+    let corner_dy = cy; 
+    let max_dist_sq = (corner_dx * corner_dx + corner_dy * corner_dy) as f32;
+
+    if max_dist_sq == 0.0 {return;}
+    let inv_max_dist_sq = intensity / max_dist_sq;
+
+    let buf = photon_image.raw_pixels.as_mut_slice();
+
+    let mut x: usize = 0;
+    let mut y: usize = 0;
+
+    let end = buf.len();
+    for i in (0..end).step_by(4) {
+        let dx = x as i64 - cx;
+        let dy = y as i64 - cy;
+        let dist_sq = (dx * dx + dy * dy) as f32;
+
+        let factor = (1.0_f32 - dist_sq * inv_max_dist_sq).clamp(0.0, 1.0);
+
+        buf[i]     = (buf[i]     as f32 * factor) as u8;
+        buf[i + 1] = (buf[i + 1] as f32 * factor) as u8;
+        buf[i + 2] = (buf[i + 2] as f32 * factor) as u8;
+        x += 1;
+        if x == width {
+            x = 0;
+            y += 1;
+        }
     }
 }

--- a/crate/src/filters.rs
+++ b/crate/src/filters.rs
@@ -3,9 +3,10 @@
 use crate::channels::alter_channels;
 use crate::colour_spaces;
 use crate::colour_spaces::mix_with_colour;
-use crate::effects::{adjust_contrast, duotone, inc_brightness};
+use crate::effects::{adjust_contrast, duotone, inc_brightness, vignette};
 use crate::monochrome;
 use crate::{PhotonImage, Rgb};
+use crate::noise::film_grain;
 
 #[cfg(feature = "enable_wasm")]
 use wasm_bindgen::prelude::*;
@@ -154,6 +155,7 @@ pub fn filter(img: &mut PhotonImage, filter_name: &str) {
         "firenze" => firenze(img),
         "obsidian" => obsidian(img),
         "lofi" => lofi(img),
+        "cinematic" => cinematic(img),
         _ => monochrome::monochrome(img, 90, 40, 80),
     };
 }
@@ -420,4 +422,34 @@ pub fn firenze(img: &mut PhotonImage) {
 pub fn obsidian(img: &mut PhotonImage) {
     monochrome::grayscale(img);
     adjust_contrast(img, 25.0);
+}
+
+/// Apply a cinematic film look to an image.
+///
+/// # Example
+///
+/// ```no_run
+/// use photon_rs::filters::cinematic;
+/// use photon_rs::native::open_image;
+///
+/// let mut img = open_image("img.jpg").expect("File should open");
+/// cinematic(&mut img);
+/// ```
+///
+/// The same effect is also available through the generic dispatcher:
+///
+/// ```no_run
+/// use photon_rs::filters::filter;
+/// use photon_rs::native::open_image;
+///
+/// let mut img = open_image("img.jpg").expect("File should open");
+/// filter(&mut img, "cinematic");
+/// ```
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
+pub fn cinematic(img: &mut PhotonImage) {
+    adjust_contrast(img, 35.0);
+    let amber = Rgb::new(255, 160, 20);
+    mix_with_colour(img, amber, 0.12);
+    film_grain(img, 0.15, false, 0xF1_1F);
+    vignette(img, 0.65);
 }

--- a/crate/src/noise.rs
+++ b/crate/src/noise.rs
@@ -113,3 +113,96 @@ pub fn pink_noise(photon_image: &mut PhotonImage) {
     }
     photon_image.raw_pixels = img.into_bytes();
 }
+
+/// Inline XorShift32 pseudo-random number generator.
+///
+/// Updates `state` in place and returns the next pseudo-random `u32`.
+/// Three XOR-shift operations produce a full-period, statistically adequate
+/// sequence suitable for visual noise without any external crate dependency.
+#[inline(always)]
+fn xorshift32(state: &mut u32) -> u32 {
+    // This specific triplet (13, 17, 5) is one of the maximal-period
+    *state ^= *state << 13;
+    *state ^= *state >> 17;
+    *state ^= *state << 5;
+    *state
+}
+
+/// Apply a cinematic film grain effect to an image.
+///
+/// Simulates analog photographic grain by adding spatially-varying noise that is weighted by each 
+/// pixel's perceptual luminance: grain is strongest in the midtones and naturally falls off toward the
+/// shadows and highlights matching the characteristic response of real photographic emulsions.
+///
+/// # Arguments
+/// * `photon_image` - A mutable reference to the [`PhotonImage`] to process.
+/// * `intensity`    - Grain strength in the range `[0.0, 1.0]`.  
+///                    `0.1` – `0.3` is a realistic film look; `1.0` is extreme.
+/// * `monochrome`   - When `true`, a single noise sample is shared across R, G and B (silver-halide style, one PRNG call per pixel).
+///                    When `false`, each channel gets an independent sample, producing the subtle colour fringing of 
+///                    multi-layer film stocks (three PRNG calls per pixel).
+///                    
+/// * `seed`         - Initial PRNG seed. Use a fixed value for reproducible results or any non-zero runtime value for variation.
+///                    Supplying `0` falls back to an internal safe constant.
+///
+/// # Example
+///
+/// ```no_run
+/// use photon_rs::noise::film_grain;
+/// use photon_rs::native::open_image;
+///
+/// let mut img = open_image("img.jpg").expect("File should open");
+/// film_grain(&mut img, 0.15, true, 42);
+/// ```
+#[cfg_attr(feature = "enable_wasm", wasm_bindgen)]
+pub fn film_grain(photon_image: &mut PhotonImage, intensity: f32, monochrome: bool, seed: u32) {
+    let intensity = intensity.clamp(0.0, 1.0);
+
+    // Constraint 3 compliance: XorShift32 is undefined for a zero state.
+    // `0xBAD5EED` is an arbitrary non-zero constant; spelling it out makes the fallback intent obvious during code review.
+    let mut state: u32 = if seed == 0 {0xBAD5EED} else {seed};
+
+    // Pre-compute the maximum signed grain magnitude in pixel units.
+    // A grain value of `max_grain` corresponds to intensity == 1.0 at the peak midtone weight
+    // the raw PRNG output is normalised to [-1, +1] and then scaled by this factor inside the loop.
+    // 127.5 chosen so that at intensity == 1.0 a fully-lit midtone pixel can swing at most ±127
+    let max_grain = intensity *127.5_f32;
+    let u32_max_recip = 1.0_f32 /u32::MAX as f32;
+
+    let buf = photon_image.raw_pixels.as_mut_slice();
+    let end = buf.len();
+
+    for i in (0..end).step_by(4) {
+        let r = buf[i]   as f32;
+        let g = buf[i+1] as f32;
+        let b = buf[i+2] as f32;
+
+        let luma =0.299 *r+0.587 *g+0.114 *b;
+
+        // midtone_weight peaks at 1.0 when luma == 127.5 (50 % grey) and falls linearly to 0.0 at pure
+        //  black (luma == 0) and pure white (luma == 255).
+        let midtone_weight = 1.0_f32 - (luma /255.0-0.5).abs() *2.0;
+
+        let grain_scale = max_grain *midtone_weight;
+        if monochrome {
+            let noise_u32 = xorshift32(&mut state);
+            let grain = (noise_u32 as f32 *u32_max_recip-0.5) *2.0 *grain_scale;
+
+            buf[i]  = (r+grain).clamp(0.0, 255.0) as u8;
+            buf[i+1]= (g+grain).clamp(0.0, 255.0) as u8;
+            buf[i+2]= (b+grain).clamp(0.0, 255.0) as u8;
+        } else {
+            let noise_r = xorshift32(&mut state);
+            let noise_g = xorshift32(&mut state);
+            let noise_b = xorshift32(&mut state);
+
+            let grain_r = (noise_r as f32 *u32_max_recip-0.5) *2.0 *grain_scale;
+            let grain_g = (noise_g as f32 *u32_max_recip-0.5) *2.0 *grain_scale;
+            let grain_b = (noise_b as f32 *u32_max_recip-0.5) *2.0 *grain_scale;
+
+            buf[i]  = (r+grain_r).clamp(0.0, 255.0) as u8;
+            buf[i+1]= (g+grain_g).clamp(0.0, 255.0) as u8;
+            buf[i+2]= (b+grain_b).clamp(0.0, 255.0) as u8;
+        }
+    }
+}

--- a/crate/src/tests.rs
+++ b/crate/src/tests.rs
@@ -7,7 +7,8 @@ mod test {
     use crate::colour_spaces::*;
     use crate::transform::{resample, seam_carve};
     use crate::PhotonImage;
-
+    use crate::effects::{bayer_dither, vignette};
+    use crate::noise::film_grain;
     #[test]
     fn test_alter_red_channel() {
         let width = 4;
@@ -379,7 +380,6 @@ mod test {
             assert_eq!(result.get_raw_pixels(), correct_pix);
         }
         {
-            // Downsample width and upsample height.
             let new_w: usize = 160;
             let new_h: usize = 320;
             let channels = 4;
@@ -392,7 +392,6 @@ mod test {
             assert_eq!(result.get_raw_pixels(), correct_pix);
         }
         {
-            // Upsample width and downsample height.
             let new_w: usize = 320;
             let new_h: usize = 120;
             let channels = 4;
@@ -404,5 +403,144 @@ mod test {
             assert_eq!(result.get_height(), new_h as u32);
             assert_eq!(result.get_raw_pixels(), correct_pix);
         }
+    }
+    
+    #[test]
+    fn test_bayer_dither_depth1_binary_output() {
+        let width  = 8_u32;
+        let height = 8_u32;
+        let raw_pix: Vec<u8> = std::iter::repeat([128_u8, 128_u8, 128_u8, 255_u8])
+            .take((width * height) as usize)
+            .flatten()
+            .collect();
+
+        let mut img = PhotonImage::new(raw_pix, width, height);
+        bayer_dither(&mut img, 1, 1.0);
+
+        let out = img.get_raw_pixels();
+        for i in (0..out.len()).step_by(4) {
+            assert!(
+                out[i]     == 0 || out[i]     == 255,
+                "R channel value {} is not binary at depth=1", out[i]
+            );
+            assert!(
+                out[i + 1] == 0 || out[i + 1] == 255,
+                "G channel value {} is not binary at depth=1", out[i + 1]
+            );
+            assert!(
+                out[i + 2] == 0 || out[i + 2] == 255,
+                "B channel value {} is not binary at depth=1", out[i + 2]
+            );
+        }
+    }
+
+    #[test]
+    fn test_film_grain_preserves_dimensions() {
+        let width  = 4_u32;
+        let height = 4_u32;
+        let raw_pix: Vec<u8> = std::iter::repeat([128_u8, 128_u8, 128_u8, 255_u8])
+            .take((width * height) as usize)
+            .flatten()
+            .collect();
+
+        let mut img = PhotonImage::new(raw_pix, width, height);
+        film_grain(&mut img, 0.5, true, 42);
+
+        assert_eq!(img.get_width(),  width,  "width must be unchanged after film_grain");
+        assert_eq!(img.get_height(), height, "height must be unchanged after film_grain");
+        assert_eq!(
+            img.get_raw_pixels().len(),
+            (width * height * 4) as usize,
+            "pixel buffer length must be unchanged after film_grain"
+        );
+    }
+    #[test]
+    fn test_film_grain_deterministic_with_fixed_seed() {
+        let width  = 4_u32;
+        let height = 4_u32;
+        let raw_pix: Vec<u8> = std::iter::repeat([100_u8, 150_u8, 200_u8, 255_u8])
+            .take((width * height) as usize)
+            .flatten()
+            .collect();
+
+        let mut img_a = PhotonImage::new(raw_pix.clone(), width, height);
+        let mut img_b = PhotonImage::new(raw_pix,         width, height);
+
+        film_grain(&mut img_a, 0.3, false, 12345);
+        film_grain(&mut img_b, 0.3, false, 12345);
+
+        assert_eq!(
+            img_a.get_raw_pixels(),
+            img_b.get_raw_pixels(),
+            "film_grain must produce identical output for the same seed"
+        );
+    }
+    #[test]
+    fn test_vignette_corners_darker_than_centre() {
+        let width  = 6_u32;
+        let height = 6_u32;
+        let fill   = 200_u8;
+        let raw_pix: Vec<u8> = std::iter::repeat([fill, fill, fill, 255_u8])
+            .take((width * height) as usize)
+            .flatten()
+            .collect();
+
+        let mut img = PhotonImage::new(raw_pix, width, height);
+        vignette(&mut img, 0.8);
+
+        let out = img.get_raw_pixels();
+
+        let corner_r = out[0] as i32;
+        let centre_idx = (3 * width as usize + 3) * 4;
+        let centre_r   = out[centre_idx] as i32;
+
+        assert!(
+            corner_r < centre_r,
+            "corner pixel ({}) should be darker than centre pixel ({}) after vignette",
+            corner_r, centre_r
+        );
+    }
+
+    #[test]
+    fn test_cinematic_filter_with_vignette_smoke() {
+        use crate::filters::cinematic;
+
+        let width  = 6_u32;
+        let height = 6_u32;
+        let raw_pix: Vec<u8> = std::iter::repeat([120_u8, 80_u8, 60_u8, 255_u8])
+            .take((width * height) as usize)
+            .flatten()
+            .collect();
+
+        let mut img = PhotonImage::new(raw_pix, width, height);
+        cinematic(&mut img);
+
+        assert_eq!(img.get_width(),  width);
+        assert_eq!(img.get_height(), height);
+        assert_eq!(
+            img.get_raw_pixels().len(),
+            (width * height * 4) as usize
+        );
+    }
+    #[test]
+    fn test_cinematic_filter_smoke() {
+        use crate::filters::cinematic;
+
+        let width  = 4_u32;
+        let height = 4_u32;
+        let raw_pix: Vec<u8> = std::iter::repeat([120_u8, 80_u8, 60_u8, 255_u8])
+            .take((width * height) as usize)
+            .flatten()
+            .collect();
+
+        let mut img = PhotonImage::new(raw_pix, width, height);
+        cinematic(&mut img);  
+
+        assert_eq!(img.get_width(),  width);
+        assert_eq!(img.get_height(), height);
+        assert_eq!(
+            img.get_raw_pixels().len(),
+            (width * height * 4) as usize
+        );
     }
 }


### PR DESCRIPTION
This PR adds several new image effects and a cinematic filter to the library.

Specifically, it introduces Bayer ordered dithering for issue #215, as well as a vignette effect and a film grain effect. These are available both as standalone functions and through the existing filter system.

A new "cinematic" filter is also included, which combines multiple effects (contrast adjustment, subtle color tint, grain, and vignette) to produce a stylized look with a single call.

Tests have been added for all new functionality, covering basic output behavior, deterministic results where applicable (e.g., seeded grain), and ensuring that image dimensions are preserved.

Closes #215.
