### PR TITLE
fix(noise): WASM rng cfg gates check wasm64, so wasm32 browser builds still panic

### DIFF
--- a/crate/src/noise.rs
+++ b/crate/src/noise.rs
@@ -8,7 +8,7 @@ use wasm_bindgen::prelude::*;
 #[cfg(all(target_family = "wasm", not(target_os = "wasi")))]
 use js_sys::Math::random;
 
-#[cfg(not(all(target_arch = "wasm64", not(target_os = "wasi"))))]
+#[cfg(not(all(target_family = "wasm", not(target_os = "wasi"))))]
 use rand::Rng;
 
 /// Add randomized noise to an image.
@@ -34,14 +34,14 @@ use rand::Rng;
 pub fn add_noise_rand(photon_image: &mut PhotonImage) {
     let buf = photon_image.raw_pixels.as_mut_slice();
 
-    #[cfg(not(all(target_arch = "wasm64", not(target_os = "wasi"))))]
+    #[cfg(not(all(target_family = "wasm", not(target_os = "wasi"))))]
     let mut rng = rand::thread_rng();
 
     for i in (0..buf.len()).step_by(4) {
-        #[cfg(not(all(target_arch = "wasm64", not(target_os = "wasi"))))]
+        #[cfg(not(all(target_family = "wasm", not(target_os = "wasi"))))]
         let offset = rng.gen_range(0, 150);
 
-        #[cfg(all(target_arch = "wasm64", not(target_os = "wasi")))]
+        #[cfg(all(target_family = "wasm", not(target_os = "wasi")))]
         let offset = (random() * 150.0) as u8;
 
         for c in 0..3 {
@@ -71,13 +71,13 @@ pub fn add_noise_rand(photon_image: &mut PhotonImage) {
 pub fn pink_noise(photon_image: &mut PhotonImage) {
     let buf = photon_image.raw_pixels.as_mut_slice();
 
-    #[cfg(not(all(target_arch = "wasm64", not(target_os = "wasi"))))]
+    #[cfg(not(all(target_family = "wasm", not(target_os = "wasi"))))]
     let mut rng = rand::thread_rng();
 
-    #[cfg(not(all(target_arch = "wasm64", not(target_os = "wasi"))))]
+    #[cfg(not(all(target_family = "wasm", not(target_os = "wasi"))))]
     let mut rng_gen = move || rng.gen();
 
-    #[cfg(all(target_arch = "wasm64", not(target_os = "wasi")))]
+    #[cfg(all(target_family = "wasm", not(target_os = "wasi")))]
     let rng_gen = || random();
 
     for i in (0..buf.len()).step_by(4) {


### PR DESCRIPTION
## The bug

`add_noise_rand` and `pink_noise` panic with `RuntimeError: unreachable` in every browser WASM build, despite the **[WASM SUPPORT IS AVAILABLE]** docstrings.

The `js_sys::Math::random` workaround introduced in #162 is gated at every **use site** on:

```rust
#[cfg(all(target_arch = "wasm64", not(target_os = "wasi")))]
```

Browser builds target `wasm32-unknown-unknown`, which fails that condition - so they compile the `rand::thread_rng()` branch instead, and `thread_rng` has no entropy source on wasm32-unknown-unknown, panicking on first call. (The `use js_sys::Math::random` import at the top of the file is already gated on `target_family = "wasm"`, which is why the import compiles but goes unused on wasm32.)

## The fix

Switch the seven use-site gates from `target_arch = "wasm64"` to `target_family = "wasm"`, matching the existing import gate. wasm32 + wasm64 both take the `Math.random` path; native keeps `rand::thread_rng()`.

## Verification

- `cargo check` clean on `wasm32-unknown-unknown` and native (aarch64-apple-darwin).
- Runtime, via `wasm-pack build --target nodejs` of master vs this branch:

```
master:      add_noise_rand -> RuntimeError: unreachable
this branch: add_noise_rand + pink_noise run and mutate pixels
```

Context: we hit this in production on [Photon Lab](https://watt3d.dev/photon-lab/) (a browser playground built on photon-rs) and had to cut the noise functions from the UI; this one-line-class fix would let us (and anyone on `@silvia-odwyer/photon`) re-enable them once released.

Thanks for photon - it's a joy to build on.