### PR TITLE
Fix memory ratcheting on WASM

### DIFF
--- a/crate/src/lib.rs
+++ b/crate/src/lib.rs
@@ -235,12 +235,19 @@ impl PhotonImage {
         // write_to owns the lossy/lossless encoder choice, so one clone is
         // the floor here.
         let img = ImageRgba8(
-            image::ImageBuffer::from_raw(self.width, self.height, self.raw_pixels.clone())
-                .unwrap(),
+            image::ImageBuffer::from_raw(
+                self.width,
+                self.height,
+                self.raw_pixels.clone(),
+            )
+            .unwrap(),
         );
         let mut buffer = vec![];
-        img.write_to(&mut Cursor::new(&mut buffer), image::ImageOutputFormat::WebP)
-            .unwrap();
+        img.write_to(
+            &mut Cursor::new(&mut buffer),
+            image::ImageOutputFormat::WebP,
+        )
+        .unwrap();
         buffer
     }
 

--- a/crate/src/lib.rs
+++ b/crate/src/lib.rs
@@ -40,8 +40,11 @@
 //! View the [official demo of WASM in action](https://silvia-odwyer.github.io/photon).
 
 use base64::{decode, encode};
+use image::codecs::jpeg::JpegEncoder;
+use image::codecs::png::PngEncoder;
 use image::DynamicImage::ImageRgba8;
 use image::GenericImage;
+use image::ImageEncoder;
 use serde::{Deserialize, Serialize};
 use std::io::Cursor;
 
@@ -103,12 +106,17 @@ impl PhotonImage {
 
         let img = image::load_from_memory(slice).unwrap();
 
-        let raw_pixels = img.to_rgba8().to_vec();
+        let width = img.width();
+        let height = img.height();
+
+        // Consume the decode instead of cloning it; transient full-frame
+        // copies permanently grow wasm linear memory.
+        let raw_pixels = img.into_rgba8().into_raw();
 
         PhotonImage {
             raw_pixels,
-            width: img.width(),
-            height: img.height(),
+            width,
+            height,
         }
     }
 
@@ -184,12 +192,7 @@ impl PhotonImage {
 
     /// Convert the PhotonImage to base64.
     pub fn get_base64(&self) -> String {
-        let mut img = helpers::dyn_image_from_raw(self);
-        img = ImageRgba8(img.to_rgba8());
-
-        let mut buffer = vec![];
-        img.write_to(&mut Cursor::new(&mut buffer), image::ImageOutputFormat::Png)
-            .unwrap();
+        let buffer = self.get_bytes();
         let base64 = encode(&buffer);
 
         let res_base64 = format!("data:image/png;base64,{}", base64.replace("\r\n", ""));
@@ -199,32 +202,44 @@ impl PhotonImage {
 
     /// Convert the PhotonImage to raw bytes. Returns PNG.
     pub fn get_bytes(&self) -> Vec<u8> {
-        let mut img = helpers::dyn_image_from_raw(self);
-        img = ImageRgba8(img.to_rgba8());
+        // Encode straight from raw_pixels; a DynamicImage round-trip would
+        // clone the frame twice.
         let mut buffer = vec![];
-        img.write_to(&mut Cursor::new(&mut buffer), image::ImageOutputFormat::Png)
+        PngEncoder::new(Cursor::new(&mut buffer))
+            .write_image(
+                &self.raw_pixels,
+                self.width,
+                self.height,
+                image::ColorType::Rgba8,
+            )
             .unwrap();
         buffer
     }
 
     /// Convert the PhotonImage to raw bytes. Returns a JPEG.
     pub fn get_bytes_jpeg(&self, quality: u8) -> Vec<u8> {
-        let mut img = helpers::dyn_image_from_raw(self);
-        img = ImageRgba8(img.to_rgba8());
         let mut buffer = vec![];
-        let out_format = image::ImageOutputFormat::Jpeg(quality);
-        img.write_to(&mut Cursor::new(&mut buffer), out_format)
+        JpegEncoder::new_with_quality(Cursor::new(&mut buffer), quality)
+            .write_image(
+                &self.raw_pixels,
+                self.width,
+                self.height,
+                image::ColorType::Rgba8,
+            )
             .unwrap();
         buffer
     }
 
     /// Convert the PhotonImage to raw bytes. Returns a WEBP.
     pub fn get_bytes_webp(&self) -> Vec<u8> {
-        let mut img = helpers::dyn_image_from_raw(self);
-        img = ImageRgba8(img.to_rgba8());
+        // write_to owns the lossy/lossless encoder choice, so one clone is
+        // the floor here.
+        let img = ImageRgba8(
+            image::ImageBuffer::from_raw(self.width, self.height, self.raw_pixels.clone())
+                .unwrap(),
+        );
         let mut buffer = vec![];
-        let out_format = image::ImageOutputFormat::WebP;
-        img.write_to(&mut Cursor::new(&mut buffer), out_format)
+        img.write_to(&mut Cursor::new(&mut buffer), image::ImageOutputFormat::WebP)
             .unwrap();
         buffer
     }

--- a/crate/src/transform.rs
+++ b/crate/src/transform.rs
@@ -1,5 +1,7 @@
 //! Image transformations, ie: scale, crop, resize, etc.,
 
+// Only resize_img_browser still needs helpers.
+#[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
 use crate::helpers;
 use crate::iter::ImageIterator;
 use crate::{PhotonImage, Rgba};
@@ -272,19 +274,20 @@ pub fn resize(
 ) -> PhotonImage {
     let sampling_filter = filter_type_from_sampling_filter(sampling_filter);
 
-    let dyn_img = helpers::dyn_image_from_raw(photon_img);
-    let resized_img = ImageRgba8(image::imageops::resize(
-        &dyn_img,
-        width,
-        height,
-        sampling_filter,
-    ));
+    // Zero-copy view; imageops::resize only needs a GenericImageView.
+    let view: ImageBuffer<image::Rgba<u8>, &[u8]> = ImageBuffer::from_raw(
+        photon_img.width,
+        photon_img.height,
+        photon_img.raw_pixels.as_slice(),
+    )
+    .unwrap();
+    let resized_img = image::imageops::resize(&view, width, height, sampling_filter);
 
     let width = resized_img.width();
     let height = resized_img.height();
 
     PhotonImage {
-        raw_pixels: resized_img.into_bytes(),
+        raw_pixels: resized_img.into_raw(),
         width,
         height,
     }


### PR DESCRIPTION
Fixes #226 by keeping a single byte copy in PhotonImage instead of one copy per operation.

## Before / after

Same methodology as #226 (`WebAssembly.Memory.buffer.byteLength` after each call, 4800×3200 RGBA PNG, 58.6MB raw frame), wasm-pack `--target nodejs --release` build of this branch:

| Measurement                                             | Before (0.3.4) | After           |
| ------------------------------------------------------- | -------------- | --------------- |
| `new_from_byteslice` (decode, isolated)                 | +177.5MB (3×)  | +60.3MB (1×)    |
| `get_bytes` (PNG encode)                                | +117.3MB       | +1.6MB          |
| decode → resize → `get_bytes_jpeg`, permanent footprint | 252.1MB        | 140.6MB         |
| full lifecycle from the #226 repro script, total        | 309.1MB        | 140.5MB         |

The remaining growth at the `resize` step (~79MB) is `image::imageops::resize`'s internal intermediate buffer, not a photon-side copy — out of scope here.

## Verification

- All 326 crate tests pass.
- Outputs are byte-for-byte identical to the published 0.3.4 build on the same input: resized pixels, JPEG bytes, and PNG bytes compared directly, and the patched build's encodes decode correctly in the old build.
